### PR TITLE
Update props.conf

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -9,8 +9,8 @@ sourcetype = eventgen
 
 [source::...eventgen_metrics.log]
 sourcetype = eventgen_metrics
-kv_mode = json
-indexed_extractions = json
+KV_MODE = json
+INDEXED_EXTRACTIONS = JSON
 
 [eventgen]
 REPORT-sample-app_for_eventgen = sample-app_for_eventgen


### PR DESCRIPTION
Fixes startup warnings in splunk by changing the case of some attributes and field values.