### PR TITLE
fix for csv index override + jinja/weblog generators

### DIFF
--- a/splunk_eventgen/lib/eventgensamples.py
+++ b/splunk_eventgen/lib/eventgensamples.py
@@ -372,6 +372,18 @@ class Sample(object):
                 csvReader = csv.DictReader(self._sampleFH)
                 for line in csvReader:
                     if '_raw' in line:
+                        # Use conf-defined values for these params instead of sample-defined ones
+                        current_line_keys = line.keys()
+                        if "host" not in current_line_keys:
+                            line["host"] = self.host
+                        if "hostRegex" not in current_line_keys:
+                            line["hostRegex"] = self.hostRegex
+                        if "source" not in current_line_keys:
+                            line["source"] = self.source
+                        if "sourcetype" not in current_line_keys:
+                            line["sourcetype"] = self.sourcetype
+                        if "index" not in current_line_keys:
+                            line["index"] = self.index
                         self.sampleDict.append(line)
                         self.sampleLines.append(line['_raw'])
                     else:

--- a/splunk_eventgen/lib/plugins/generator/jinja.py
+++ b/splunk_eventgen/lib/plugins/generator/jinja.py
@@ -248,6 +248,8 @@ class JinjaGenerator(GeneratorPlugin):
                                 target_line["source"] = self._sample.source
                             if "sourcetype" not in current_line_keys:
                                 target_line["sourcetype"] = self._sample.sourcetype
+                            if "index" not in current_line_keys:
+                                target_line["index"] = self._sample.index
                             lines_out.append(target_line)
                         else:
                             break

--- a/splunk_eventgen/lib/plugins/generator/weblog.py
+++ b/splunk_eventgen/lib/plugins/generator/weblog.py
@@ -31,23 +31,22 @@ class WeblogGenerator(GeneratorPlugin):
     def gen(self, count, earliest, latest, **kwargs):
         # logger.debug("weblog: external_ips_len: %s webhosts_len: %s useragents_len: %s webserverstatus_len: %s" % \
                     # (self.external_ips_len, self.webhosts_len, self.useragents_len, self.webserverstatus_len))
-        l = [ { '_raw': ('%s %s - - [%s] ' \
-                + '"GET /product.screen?product_id=HolyGouda&JSESSIONID=SD3SL1FF7ADFF8 HTTP 1.1" '\
-                + '%s %s "http://shop.buttercupgames.com/cart.do?action=view&itemId=HolyGouda" '\
+        l = [ { '_raw': ('%s %s - - [%s] '
+                + '"GET /product.screen?product_id=HolyGouda&JSESSIONID=SD3SL1FF7ADFF8 HTTP 1.1" '
+                + '%s %s "http://shop.buttercupgames.com/cart.do?action=view&itemId=HolyGouda" '
                 + '"%s" %s') % \
-                (self.external_ips[random.randint(0, self.external_ips_len-1)], \
-                self.webhosts[random.randint(0, self.webhosts_len-1)], \
-                latest.strftime('%d/%b/%Y %H:%M:%S:%f'), \
-                self.webserverstatus[random.randint(0, self.webserverstatus_len-1)], \
-                random.randint(100, 1000), \
-                self.useragents[random.randint(0, self.useragents_len-1)], \
+                (self.external_ips[random.randint(0, self.external_ips_len-1)],
+                self.webhosts[random.randint(0, self.webhosts_len-1)],
+                latest.strftime('%d/%b/%Y %H:%M:%S:%f'),
+                self.webserverstatus[random.randint(0, self.webserverstatus_len-1)],
+                random.randint(100, 1000),
+                self.useragents[random.randint(0, self.useragents_len-1)],
                 random.randint(200, 2000)),
-                'index': 'main',
-                'sourcetype': 'access_combined',
-                'host': 'log.buttercupgames.com',
-                'source': '/opt/access_combined.log',
+                'index': self._sample.index,
+                'sourcetype': self._sample.sourcetype,
+                'host': self._sample.host,
+                'source': self._sample.source,
                 '_time': int(time.mktime(latest.timetuple())) } for i in xrange(count) ]
-
 
         self._out.bulksend(l)
         return 0

--- a/tests/sample_eventgen_conf/perf/eventgen.conf.perfsample
+++ b/tests/sample_eventgen_conf/perf/eventgen.conf.perfsample
@@ -7,7 +7,6 @@ latest = now
 interval = 1
 randomizeEvents = true
 backfill = -10m
-end = 1
 
 token.0.token = \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}
 token.0.replacementType = timestamp

--- a/tests/sample_eventgen_conf/perf/eventgen.conf.perfsampleweblog
+++ b/tests/sample_eventgen_conf/perf/eventgen.conf.perfsampleweblog
@@ -16,7 +16,6 @@ dayOfWeekRate = { "0": 0.97, "1": 0.95, "2": 0.90, "3": 0.97, "4": 1.0, "5": 0.9
 randomizeCount = 0.33
 randomizeEvents = true
 backfill = -3d
-end = 1
 
 # replace timestamp
 token.0.token = \d{1,2}/\w{3}/\d{4}\s\d{2}:\d{2}:\d{2}:\d{1,3}

--- a/tests/sample_eventgen_conf/perf/eventgen.conf.perfsampleweblog-s2s
+++ b/tests/sample_eventgen_conf/perf/eventgen.conf.perfsampleweblog-s2s
@@ -18,7 +18,6 @@ dayOfWeekRate = { "0": 0.97, "1": 0.95, "2": 0.90, "3": 0.97, "4": 1.0, "5": 0.9
 randomizeCount = 0.33
 randomizeEvents = true
 backfill = -3d
-end = 1
 
 # replace timestamp
 token.0.token = \d{1,2}/\w{3}/\d{4}\s\d{2}:\d{2}:\d{2}:\d{1,3}

--- a/tests/sample_eventgen_conf/perf/eventgen.conf.perfweblog
+++ b/tests/sample_eventgen_conf/perf/eventgen.conf.perfweblog
@@ -6,4 +6,3 @@ interval = 3
 count = 2000
 outputMode = devnull
 backfill = -1h
-end = 1

--- a/tests/sample_eventgen_conf/perf/eventgen.conf.perfwindbag
+++ b/tests/sample_eventgen_conf/perf/eventgen.conf.perfwindbag
@@ -6,4 +6,3 @@ interval = 10
 count = 50000
 outputMode = devnull
 backfill = -1d
-end = 1


### PR DESCRIPTION
- Events generated by .csv sample files will use the index value from either the local or default .conf files
- Jinja generator now grabs and uses the local index value, if defined
- Weblog generator now grabs and uses the local index, source, sourcetype, and host, if defined
- Cleaned up some test samples and syntax warnings