### PR TITLE
Added a future event generation for replay generator

### DIFF
--- a/splunk_eventgen/lib/eventgenconfig.py
+++ b/splunk_eventgen/lib/eventgenconfig.py
@@ -657,14 +657,14 @@ class Config(object):
                 s.generator = 'perdayvolumegenerator'
             elif s.mode == 'replay':
                 self.logger.debug("Setting defaults for replay samples")
-                s.earliest = 'now'
-                s.latest = 'now'
+                s.earliest = 'now' if not s.earliest else s.earliest
+                s.latest = 'now' if not s.latest else s.latest
                 s.count = 1
                 s.randomizeCount = None
                 s.hourOfDayRate = None
                 s.dayOfWeekRate = None
                 s.minuteOfHourRate = None
-                s.interval = 0
+                s.interval = 0 if not s.interval else s.interval
                 # 12/29/13 CS Moved replay generation to a new replay generator plugin
                 s.generator = 'replay'
 

--- a/splunk_eventgen/lib/eventgensamples.py
+++ b/splunk_eventgen/lib/eventgensamples.py
@@ -243,18 +243,28 @@ class Sample(object):
         else:
             if self.backfill[0] == '-':
                 backfill_time = self.backfill[1:-1]
+                time_unit = self.backfill[-1]
                 if self.backfill[-2:] == 'ms':
+                    time_unit = 'ms'
                     backfill_time = self.backfill[1:-2]
-                    return current_time - datetime.timedelta(milliseconds=int(backfill_time))
-                elif self.backfill[-1] == 's':
-                    return current_time - datetime.timedelta(seconds=int(backfill_time))
-                elif self.backfill[-1] == 'm':
-                    return current_time - datetime.timedelta(minutes=int(backfill_time))
-                elif self.backfill[-1] == 'h':
-                    return current_time - datetime.timedelta(hours=int(backfill_time))
-                elif self.backfill[-1] == 'd':
-                    return current_time - datetime.timedelta(days=int(backfill_time))
+                return get_time_difference(current_time=current_time, different_time=backfill_time, sign='-', time_unit=time_unit)
+            else:
+                self.logger.error("Backfill time is not in the past.")
         return current_time
+    
+    def get_time_difference(self, current_time, different_time, sign='-', time_unit='ms'):
+        if time_unit == 'ms':
+            return current_time + (int(sign + '1') * datetime.timedelta(milliseconds=int(different_time)))
+        elif time_unit == 's':
+            return current_time + (int(sign + '1') * datetime.timedelta(seconds=int(different_time)))
+        elif time_unit == 'm':
+            return current_time + (int(sign + '1') * datetime.timedelta(minutes=int(different_time)))
+        elif time_unit == 'h':
+            return current_time + (int(sign + '1') * datetime.timedelta(hours=int(different_time)))
+        elif time_unit == 'd':
+            return current_time + (int(sign + '1') * datetime.timedelta(days=int(different_time)))
+
+
 
 
     def earliestTime(self):

--- a/splunk_eventgen/lib/eventgentimer.py
+++ b/splunk_eventgen/lib/eventgentimer.py
@@ -135,6 +135,7 @@ class Timer(object):
 
                     et = self.sample.earliestTime()
                     lt = self.sample.latestTime()
+
                     try:
                         if count < 1:
                             self.logger.info("There is no data to be generated in worker {0} because the count is {1}.".format(self.sample.config.generatorWorkers, count))


### PR DESCRIPTION
We are now supporting future events for the replay module. Splunk handles indexing future events so you can pre-generate all your future events and Splunk will index it at the future time as real data would come in.