### PR TITLE
sync server status and add completed status

### DIFF
--- a/splunk_eventgen/eventgen_core.py
+++ b/splunk_eventgen/eventgen_core.py
@@ -63,6 +63,7 @@ class EventGenerator(object):
         '''
         self.stopping = False
         self.started = False
+        self.completed = False
         self.config = None
         self.args = args
 
@@ -455,6 +456,7 @@ class EventGenerator(object):
         self.stopping = False
         self.started = True
         self.config.stopping = False
+        self.completed = False
         if len(self.config.samples) <= 0:
             self.logger.info("No samples found.  Exiting.")
         for s in self.config.samples:
@@ -498,6 +500,7 @@ class EventGenerator(object):
                 time.sleep(5)
             self.logger.info("All timers have finished, signalling workers to exit.")
             self.stop()
+            self.completed = True
         except Exception as e:
             self.logger.exception(e)
             raise e

--- a/splunk_eventgen/eventgen_nameko_server.py
+++ b/splunk_eventgen/eventgen_nameko_server.py
@@ -79,8 +79,13 @@ class EventgenServer(object):
         '''
         res = dict()
         if self.eventgen_dependency.eventgen.check_running():
+            # running
             status = 1
+        elif self.eventgen_dependency.eventgen.completed == True:
+            # all samples completed and stop
+            status = 2
         else:
+            # not start yet
             status = 0
         res["EVENTGEN_STATUS"] = status
         res["EVENTGEN_HOST"] = self.host
@@ -160,7 +165,7 @@ Output Queue Status: {7}\n'''
                 return "There is not config file known to eventgen. Pass in the config file to /conf before you start."
             if self.eventgen_dependency.eventgen.check_running():
                 return "Eventgen already started."
-            self.eventgen_dependency.eventgen.start(join_after_start=False)
+            self.eventgen_dependency.eventgen.start(join_after_start=True)
             return "Eventgen has successfully started."
         except Exception as e:
             self.log.exception(e)


### PR DESCRIPTION
1. Use timestamp to sync the server status before they are send out by the controller. https://jira.splunk.com/browse/FAST-11390
2. “Eventgen_Status” would be number 2 if all the samples tasks are completed.
(ps: the changes of status from the server are as follow:
before: 0 is not run, 1 is running.
after: 0 is not start yet, 1 is running, 2 is  stopped because of all tasks are completed.)
