### PR TITLE
Modinput bugfix

### DIFF
--- a/splunk_eventgen/lib/eventgenconfig.py
+++ b/splunk_eventgen/lib/eventgenconfig.py
@@ -311,7 +311,8 @@ class Config(object):
                 # Get the latest token number of the current stanza
                 last_token_number = 0
                 for key, value in settings.items():
-                    if 'token' in key and int(key[6]) > last_token_number:
+                    self.logger.info("key: {0}\nvalue: {1}".format(key, value))
+                    if 'token' in key and key[6].isdigit() and int(key[6]) > last_token_number:
                         last_token_number = int(key[6])
 
                 # Apply global tokens to the current stanza

--- a/splunk_eventgen/lib/eventgenconfig.py
+++ b/splunk_eventgen/lib/eventgenconfig.py
@@ -311,7 +311,6 @@ class Config(object):
                 # Get the latest token number of the current stanza
                 last_token_number = 0
                 for key, value in settings.items():
-                    self.logger.info("key: {0}\nvalue: {1}".format(key, value))
                     if 'token' in key and key[6].isdigit() and int(key[6]) > last_token_number:
                         last_token_number = int(key[6])
 

--- a/splunk_eventgen/splunk_app/lib/modinput/fields.py
+++ b/splunk_eventgen/splunk_app/lib/modinput/fields.py
@@ -439,10 +439,11 @@ class VerbosityField(Field):
         Field.to_python(self, value)
 
         if value is not None:
-            if int(value) % 10 == 0:
+            if 10 <= value <= 50 and int(value) % 10 == 0:
                 return int(value)
             else:
-                raise FieldValidationException('Invalid value provided for verbosity')
+                raise FieldValidationException('Invalid value provided for verbosity, must be one of the following: ' +
+                                               '{10, 20, 30, 40, 50}')
         else:
             return None
 


### PR DESCRIPTION
- Support for Splunk SPL Examples app: modinput can now parse and index events without hitting a ValueError
- Added safety check for allowed range of "verbosity" param and made its exception message more informative