### PR TITLE
Fix safety check and broken pipe

### DIFF
--- a/splunk_eventgen/lib/plugins/output/modinput.py
+++ b/splunk_eventgen/lib/plugins/output/modinput.py
@@ -39,7 +39,7 @@ class ModInputOutputPlugin(OutputPlugin):
                 except IndexError:
                     m = False
 
-        print out
+        sys.stdout.write(out)
         sys.stdout.flush()
 
     def _setup_logging(self):

--- a/splunk_eventgen/splunk_app/lib/modinput/fields.py
+++ b/splunk_eventgen/splunk_app/lib/modinput/fields.py
@@ -440,7 +440,7 @@ class VerbosityField(Field):
         value = int(value)
 
         if value is not None:
-            if 10 <= value <= 50 and value % 10 == 0:
+            if value in [10, 20, 30, 40, 50]:
                 return value
             else:
                 raise FieldValidationException('Invalid value provided for verbosity, must be one of the following: ' +

--- a/splunk_eventgen/splunk_app/lib/modinput/fields.py
+++ b/splunk_eventgen/splunk_app/lib/modinput/fields.py
@@ -437,10 +437,11 @@ class VerbosityField(Field):
     def to_python(self, value):
 
         Field.to_python(self, value)
+        value = int(value)
 
         if value is not None:
-            if 10 <= value <= 50 and int(value) % 10 == 0:
-                return int(value)
+            if 10 <= value <= 50 and value % 10 == 0:
+                return value
             else:
                 raise FieldValidationException('Invalid value provided for verbosity, must be one of the following: ' +
                                                '{10, 20, 30, 40, 50}')


### PR DESCRIPTION
Fixed a mistake I made where modinput would not allow users to change the logging verbosity and changed the output statement style to prevent broken pipes.