### PR TITLE
fix FAST-12048, ts is not correct in sample non-backfill mode

### DIFF
--- a/splunk_eventgen/lib/eventgentimestamp.py
+++ b/splunk_eventgen/lib/eventgentimestamp.py
@@ -5,7 +5,19 @@ import random
 class EventgenTimestamp(object):
 
     @staticmethod
-    def get_random_timestamp(earliest, latest, sample_earliest, sample_latest):
+    def get_random_timestamp(earliest, latest):
+        if type(earliest) != datetime.datetime or type(latest) != datetime.datetime:
+            raise Exception("Earliest {0} or latest {1} arguments are not datetime objects".format(earliest, latest))
+
+        earliest_in_epoch = time.mktime(earliest.timetuple())
+        latest_in_epoch = time.mktime(latest.timetuple())
+        if earliest_in_epoch > latest_in_epoch:
+            raise Exception("Latest time is earlier than earliest time.")
+
+        return datetime.datetime.fromtimestamp(random.randint(earliest_in_epoch, latest_in_epoch))
+
+    @staticmethod
+    def get_random_timestamp_backfill(earliest, latest, sample_earliest, sample_latest):
         '''
 
         earliest and latest timestamp gets generated with an interval
@@ -15,18 +27,20 @@ class EventgenTimestamp(object):
         '''
         if type(earliest) != datetime.datetime or type(latest) != datetime.datetime:
             raise Exception("Earliest {0} or latest {1} arguments are not datetime objects".format(earliest, latest))
+
         earliest_in_epoch = time.mktime(earliest.timetuple())
         latest_in_epoch = time.mktime(latest.timetuple())
         if earliest_in_epoch > latest_in_epoch:
             raise Exception("Latest time is earlier than earliest time.")
+
         pivot_time = earliest_in_epoch
+
         sample_earliest_in_seconds = EventgenTimestamp._convert_time_difference_to_seconds(sample_earliest)
         sample_latest_in_seconds = EventgenTimestamp._convert_time_difference_to_seconds(sample_latest)
+
         earliest_pivot_time = pivot_time + sample_earliest_in_seconds
         latest_pivot_time = pivot_time + sample_latest_in_seconds
-        pivot_time_range = latest_pivot_time - earliest_pivot_time
-        random_pivot_time = earliest_pivot_time + random.randint(0, pivot_time_range)
-        return datetime.datetime.fromtimestamp(random_pivot_time)
+        return datetime.datetime.fromtimestamp(random.randint(earliest_pivot_time, latest_pivot_time))
 
 
     @staticmethod

--- a/splunk_eventgen/lib/generatorplugin.py
+++ b/splunk_eventgen/lib/generatorplugin.py
@@ -49,8 +49,7 @@ class GeneratorPlugin(object):
                 # Maintain state for every token in a given event, Hash contains keys for each file name which is
                 # assigned a list of values picked from a random line in that file
                 mvhash = {}
-                pivot_timestamp = EventgenTimestamp.get_random_timestamp(earliest, latest, self._sample.earliest,
-                                                                         self._sample.latest)
+                pivot_timestamp = EventgenTimestamp.get_random_timestamp(earliest, latest)
                 ## Iterate tokens
                 for token in self._sample.tokens:
                     token.mvhash = mvhash

--- a/splunk_eventgen/lib/plugins/generator/replay.py
+++ b/splunk_eventgen/lib/plugins/generator/replay.py
@@ -68,7 +68,7 @@ class ReplayGenerator(GeneratorPlugin):
         self.backfill_time = self._sample.get_backfill_time(self.current_time)
 
         if not self._sample.backfill or self._sample.backfilldone:
-            self.backfill_time = EventgenTimestamp.get_random_timestamp(earliest, latest, self._sample.earliest, self._sample.latest)
+            self.backfill_time = EventgenTimestamp.get_random_timestamp_backfill(earliest, latest, self._sample.earliest, self._sample.latest)
 
         for line in self._sample.get_loaded_sample():
             # Add newline to a raw line if necessary


### PR DESCRIPTION
earliest and latest ts in sample (not backfill mode) doesn't work
1 if earliest/latest is an absolute time, the events always have the timestamp that equals earliest
2 if earlist = -100d and latest = now, the events have the timestamp between -200d and -100d