### PR TITLE
Bug fix/support small per day volume load（FAST-12041）

### DIFF
--- a/splunk_eventgen/lib/plugins/generator/perdayvolumegenerator.py
+++ b/splunk_eventgen/lib/plugins/generator/perdayvolumegenerator.py
@@ -58,7 +58,7 @@ class PerDayVolumeGenerator(GeneratorPlugin):
                 sizeremaining = size - currentreadsize
                 targetlinesize = len(self._sample.sampleDict[targetline]['_raw'])
                 if size < targetlinesize:
-                    self.logger.error("Size is too small. For this interval, we need {} bytes but size of one event is {} bytes.".format(size, targetlinesize))
+                    self.logger.error("Size is too small for sample {}. For this interval, we need {} bytes but size of one event is {} bytes.".format(self._sample.name, size, targetlinesize))
                     break
                 if targetlinesize <= sizeremaining or targetlinesize*.9 <= sizeremaining:
                     currentreadsize += targetlinesize

--- a/splunk_eventgen/lib/plugins/generator/perdayvolumegenerator.py
+++ b/splunk_eventgen/lib/plugins/generator/perdayvolumegenerator.py
@@ -57,6 +57,9 @@ class PerDayVolumeGenerator(GeneratorPlugin):
                 targetline = linecount % linesinfile
                 sizeremaining = size - currentreadsize
                 targetlinesize = len(self._sample.sampleDict[targetline]['_raw'])
+                if size < targetlinesize:
+                    self.logger.error("Size is too small. For this interval, we need {} bytes but size of one event is {} bytes.".format(size, targetlinesize))
+                    break
                 if targetlinesize <= sizeremaining or targetlinesize*.9 <= sizeremaining:
                     currentreadsize += targetlinesize
                     eventsDict.append(self._sample.sampleDict[targetline])


### PR DESCRIPTION
Save the interval task size when it is smaller than one raw event size. Timer will only build a task for generator when the task size is bigger than one raw event size.