### PR TITLE
use copy instead of deepcopy

### DIFF
--- a/splunk_eventgen/lib/eventgentimer.py
+++ b/splunk_eventgen/lib/eventgentimer.py
@@ -172,7 +172,9 @@ class Timer(object):
                                 # self.generatorPlugin is only an instance, now we need a real plugin.
                                 # make a copy of the sample so if it's mutated by another process, it won't mess up geeneration
                                 # for this generator.
-                                copy_sample = copy.deepcopy(self.sample)
+                                copy_sample = copy.copy(self.sample)
+                                tokens = copy.deepcopy(self.sample.tokens)
+                                copy_sample.tokens = tokens
                                 genPlugin = self.generatorPlugin(sample=copy_sample)
                                 # need to make sure we set the queue right if we're using multiprocessing or thread modes
                                 genPlugin.updateConfig(config=self.config, outqueue=self.outputQueue)

--- a/splunk_eventgen/lib/eventgentimer.py
+++ b/splunk_eventgen/lib/eventgentimer.py
@@ -69,7 +69,7 @@ class Timer(object):
             self.sample.loadSample()
             self.logger.debug("File sample loaded successfully.")
         except TypeError:
-            self.logger.error("Error loading sample file for sample '%s'" % self._sample.name)
+            self.logger.error("Error loading sample file for sample '%s'" % self.sample.name)
             return
         return len(self.sample.sampleDict[0]['_raw'])
 


### PR DESCRIPTION
**What I did:**
  Reduce the cpu time cost in timer.
**How I did:**
  Use partial deep copy instead of deep copy when timer build a generator task.
**Detail:**
 We run our profiling job for 100 seconds with the following results:
``` 
Clock type: CPU
Ordered by: totaltime, desc
name ncall tsub ttot tavg 
/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py:145 deepcopy 1939865/191 24.41281 74.27245 0.000038
/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py:306 _reconstruct 89025/191 3.045957 74.24512 0.000834
/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py:253 _deepcopy_dict 89107/191 5.585420 74.17139 0.000832
/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py:226 _deepcopy_list 28070/1415 0.720614 72.21470 0.002573
..xyang/Project/github/eventgen/splunk_eventgen/lib/generatorplugin.py:209 PerDayVolumeGenerator.run 191/181 0.003283 12.80580 0.067046
..entgen/splunk_eventgen/lib/plugins/generator/perdayvolumegenerator.py:11 PerDayVolumeGenerator.gen 191/181 0.023425 12.80193 0.067026
..oject/github/eventgen/splunk_eventgen/lib/generatorplugin.py:42 PerDayVolumeGenerator.build_events 191/181 0.146898 12.73430 0.066672
splunk_eventgen/lib/eventgentoken.py:91 Token.replace 21202/21199 0.884945 11.25029 0.000531 
```

If we set "intervals=1", deep copy will 74% cpu time cost on our es bundle which contains 30 samples.  
**Related Story:**
  https://jira.splunk.com/browse/INFRA-10020
