### PR TITLE
Remove splunkstream queue separation

### DIFF
--- a/splunk_eventgen/lib/outputplugin.py
+++ b/splunk_eventgen/lib/outputplugin.py
@@ -48,7 +48,7 @@ class OutputPlugin(object):
 
     def run(self):
         if self.events:
-            self.flush(q=self.events)
+            self.flush(self.events)
         if self.output_counter is not None:
             self.output_counter.collect(len(self.events), sum([len(e['_raw']) for e in self.events]))
         self.events = None

--- a/splunk_eventgen/lib/plugins/output/splunkstream.py
+++ b/splunk_eventgen/lib/plugins/output/splunkstream.py
@@ -3,7 +3,6 @@ from outputplugin import OutputPlugin
 from xml.dom import minidom
 import httplib, httplib2
 import urllib
-from collections import deque
 import logging
 
 
@@ -12,10 +11,9 @@ class SplunkStreamOutputPlugin(OutputPlugin):
     name = 'splunkstream'
     MAXQUEUELENGTH = 100
 
-    validSettings = [ 'splunkMethod', 'splunkUser', 'splunkPass', 'splunkHost', 'splunkPort' ]
-    complexSettings = { 'splunkMethod': ['http', 'https'] }
-    intSettings = [ 'splunkPort' ]
-
+    validSettings = ['splunkMethod', 'splunkUser', 'splunkPass', 'splunkHost', 'splunkPort']
+    complexSettings = {'splunkMethod': ['http', 'https']}
+    intSettings = ['splunkPort']
 
     _splunkHost = None
     _splunkPort = None
@@ -33,13 +31,13 @@ class SplunkStreamOutputPlugin(OutputPlugin):
         self._splunkUrl, self._splunkMethod, self._splunkHost, self._splunkPort = c.getSplunkUrl(self._sample)
         self._splunkUser = self._sample.splunkUser
         self._splunkPass = self._sample.splunkPass
-            
-        if self._sample.sessionKey == None:
+
+        if not self._sample.sessionKey:
             try:
                 myhttp = httplib2.Http(disable_ssl_certificate_validation=True)
-                self.logger.debugv("Getting session key from '%s' with user '%s' and pass '%s'" % (self._splunkUrl + '/services/auth/login', self._splunkUser, self._splunkPass))
+                self.logger.debug("Getting session key from '%s' with user '%s' and pass '%s'" % (self._splunkUrl + '/services/auth/login', self._splunkUser, self._splunkPass))
                 response = myhttp.request(self._splunkUrl + '/services/auth/login', 'POST',
-                                            headers = {}, body=urllib.urlencode({'username': self._splunkUser, 
+                                            headers = {}, body=urllib.urlencode({'username': self._splunkUser,
                                                                                 'password': self._splunkPass}))[1]
                 self._sample.sessionKey = minidom.parseString(response).getElementsByTagName('sessionKey')[0].childNodes[0].nodeValue
                 self.logger.debug("Got new session for splunkstream, sessionKey '%s'" % self._sample.sessionKey)
@@ -51,31 +49,10 @@ class SplunkStreamOutputPlugin(OutputPlugin):
 
     def flush(self, q):
         if len(q) > 0:
-            # For faster processing, we need to break these up by source combos
-            # so they'll each get their own thread.
-            # Fixes a bug where we're losing source and sourcetype with bundlelines type transactions
-            queues = deque(q)
-            for row in q:
-                if row['source'] is None:
-                    row['source'] = ''
-                if row['sourcetype'] is None:
-                    row['sourcetype'] = ''
-                if not row['source']+'_'+row['sourcetype'] in queues:
-                    queues[row['source']+'_'+row['sourcetype']] = deque([])
-
-            # self.logger.debug("Queues setup: %s" % pprint.pformat(queues))
-            m = q.popleft()
-            while m:
-                queues[m['source']+'_'+m['sourcetype']].append(m)
-                try:
-                    m = q.popleft()
-                except IndexError:
-                    m = False
-
-            for k, queue in queues.items():
-                splunkhttp = None
+            for k, queue in q.items():
                 if len(queue) > 0:
                     streamout = ""
+                    index = source = sourcetype = host = hostRegex = None
                     # SHould now be getting a different output thread for each source
                     # So therefore, look at the first message in the queue, set based on that
                     # and move on
@@ -99,18 +76,18 @@ class SplunkStreamOutputPlugin(OutputPlugin):
                         splunkhttp = connmethod(self._splunkHost, self._splunkPort)
                         splunkhttp.connect()
                         urlparms = [ ]
-                        if index != None:
+                        if not index:
                             urlparms.append(('index', index))
-                        if source != None:
+                        if not source:
                             urlparms.append(('source', source))
-                        if sourcetype != None:
+                        if not sourcetype:
                             urlparms.append(('sourcetype', sourcetype))
-                        if hostRegex != None:
+                        if not hostRegex:
                             urlparms.append(('host_regex', hostRegex))
-                        elif host != None:
+                        elif not host:
                             urlparms.append(('host', host))
                         url = '/services/receivers/simple?%s' % (urllib.urlencode(urlparms))
-                        headers = {'Authorization': "Splunk %s" % self._sample.sessionKey }
+                        headers = {'Authorization': "Splunk %s" % self._sample.sessionKey}
 
                         while msg:
                             if msg[-1] != '\n':
@@ -136,10 +113,9 @@ class SplunkStreamOutputPlugin(OutputPlugin):
                             self.logger.error("Data not written to Splunk.  Splunk returned %s" % data)
                     except httplib.BadStatusLine:
                         self.logger.error("Received bad status from Splunk for sample '%s'" % self._sample)
-                    self.logger.debugv("Closing splunkhttp connection")
-                    if splunkhttp != None:
+                    self.logger.debug("Closing splunkhttp connection")
+                    if not splunkhttp:
                         splunkhttp.close()
-                        splunkhttp = None
 
     def _setup_logging(self):
         self.logger = logging.getLogger('eventgen')

--- a/splunk_eventgen/lib/plugins/output/splunkstream.py
+++ b/splunk_eventgen/lib/plugins/output/splunkstream.py
@@ -53,11 +53,9 @@ class SplunkStreamOutputPlugin(OutputPlugin):
                 if len(queue) > 0:
                     streamout = ""
                     index = source = sourcetype = host = hostRegex = None
-                    # SHould now be getting a different output thread for each source
-                    # So therefore, look at the first message in the queue, set based on that
-                    # and move on
                     metamsg = queue.popleft()
                     msg = metamsg['_raw']
+                    # Worried about below code
                     try:
                         index = metamsg['index']
                         source = metamsg['source']
@@ -75,7 +73,7 @@ class SplunkStreamOutputPlugin(OutputPlugin):
                             connmethod = httplib.HTTPConnection
                         splunkhttp = connmethod(self._splunkHost, self._splunkPort)
                         splunkhttp.connect()
-                        urlparms = [ ]
+                        urlparms = []
                         if not index:
                             urlparms.append(('index', index))
                         if not source:


### PR DESCRIPTION
Fixing some messy logic in the splunkstream outputter. The logic separates events by unique source/sourcetype combos and sends a single http event to splunk for each group. We now dynamically append events to the sub-queues.
Addresses issue: #132 