### PR TITLE
Fix jinja template bug under SA-Eventgen app

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -334,7 +334,7 @@ Tokens in the default generator can override the sample to allow dynamic content
     * Defaults to None.
 
 ###### Jinja
-The following optinos are only valid with the jinja generator
+The following options are only valid with the jinja generator.
 
     jinja_template_dir = <str> example: templates
     * directory name inside the current eventgen.conf dir where jinja templates can be located

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -402,7 +402,19 @@ latest = <time-str>
     * Specifies the latest random time for generated events.
     * If this value is an absolute time, use the dispatch.time_format to format the value.
     * Defaults to now.
-    
+
+#############################
+## JINJA TEMPLATE SETTINGS ##
+#############################
+
+jinja_template_dir = <str>
+    * directory name inside the current eventgen.conf dir where jinja templates can be located.
+    * default template directory is <bundle>/samples/templates if not defined.
+jinja_target_template = <str>
+    * root template to load for all sample generation.
+jinja_variables = <json>
+    * json value that contains a dict of kv pairs to pass as options to load inside of the jinja templating engine.
+
 ################################
 ## TOKEN REPLACEMENT SETTINGS ##
 ################################

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -161,4 +161,12 @@ To start generating data, simply enable the SA-Eventgen modinput by going to Set
 If you wish you add your bundle so that the modinput can detect your package:
 Package your eventgen.conf and sample files into a directory structure as outlined in the [configuration](CONFIGURE.md). After that's done, copy/move the bundle into your `${SPLUNK_HOME}/etc/apps/` directory and restart Splunk. If you have specific samples enabled in your eventgen.conf, you should see data streaming into the specified Splunk index.
 
+Make sure the bundle app permission is global. You can config this in two ways:
+* Log in to Splunk Web and navigate to Apps > Manage Apps. Find the bundle app row and set the permission to 'Global' on the Sharing column.
+* Create a folder `metadata` under the bundle with file `default.meta` and add the following content:
+```
+[]
+export=system
+```
+
 ---

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -167,6 +167,8 @@ Running Eventgen with above conf file and template would result in below output.
 With above template, Eventgen iterates through a loop of 50000 and generate the data according to the template.
 Note that the template is in a JSON format with a key "_raw" which is a raw string of data. It is necessary that you follow this pattern for Eventgen Jinja generator to work.
 
+> If you are using `SA-Eventgen` app rather than PyPi module, put `eventgen.conf` and template files into a directory structure as outlined in the [configuration](CONFIGURE.md).
+Default templates folder is `<bundle/samples/templates>`. You can also config absolute or relative path(relative to `eventgen.conf`) via `jinja_template_dir`.
 
 Let's look at how to extend an existing template.
 

--- a/splunk_eventgen/README/eventgen.conf.spec
+++ b/splunk_eventgen/README/eventgen.conf.spec
@@ -388,7 +388,19 @@ latest = <time-str>
     * Specifies the latest random time for generated events.
     * If this value is an absolute time, use the dispatch.time_format to format the value.
     * Defaults to now.
-    
+
+#############################
+## JINJA TEMPLATE SETTINGS ##
+#############################
+
+jinja_template_dir = <str>
+    * directory name inside the current eventgen.conf dir where jinja templates can be located.
+    * default template directory is <bundle>/samples/templates if not defined.
+jinja_target_template = <str>
+    * root template to load for all sample generation.
+jinja_variables = <json>
+    * json value that contains a dict of kv pairs to pass as options to load inside of the jinja templating engine.
+
 ################################
 ## TOKEN REPLACEMENT SETTINGS ##
 ################################

--- a/splunk_eventgen/lib/plugins/generator/jinja.py
+++ b/splunk_eventgen/lib/plugins/generator/jinja.py
@@ -1,15 +1,17 @@
 from __future__ import division
-from generatorplugin import GeneratorPlugin
-import datetime, time, os
+import datetime
+import time
+import os
+import random
 try:
     import ujson as json
 except:
     import json as json
-
 from jinja2 import nodes
 from jinja2.ext import Extension
 
-import random
+from generatorplugin import GeneratorPlugin
+
 
 class CantFindTemplate(Exception):
 
@@ -21,6 +23,7 @@ class CantFindTemplate(Exception):
         self.msg = msg
         super(CantFindTemplate, self).__init__(msg)
 
+
 class CantProcessTemplate(Exception):
 
     def __init__(self, msg):
@@ -31,6 +34,7 @@ class CantProcessTemplate(Exception):
         self.msg = msg
         super(CantProcessTemplate, self).__init__(msg)
 
+
 class JinjaTime(Extension):
     tags = set(['time_now', 'time_slice', 'time_delta', 'time_backfill'])
 
@@ -38,7 +42,7 @@ class JinjaTime(Extension):
     def _get_time_slice(earliest, latest, slices, target_slice, slice_type="lower"):
         """
         This method will take a time block bounded by "earliest and latest", and a slice.  It'll then divide the time
-        in sections and return a tuple with 3 arugments, the lower bound, the higher bound, and the target in the middle.
+        in sections and return a tuple with 3 arguments, the lower bound, the higher bound, and the target in the middle.
         :param earliest (in epoch):
         :param latest (in epoch):
         :param slices:
@@ -83,7 +87,7 @@ class JinjaTime(Extension):
         time_now = time.mktime(time.localtime())
         return time_now
 
-    def _time_slice_formatted(self,earliest, latest, count, slices, date_format='%Y-%m-%dT%H:%M:%S%z'):
+    def _time_slice_formatted(self, earliest, latest, count, slices, date_format='%Y-%m-%dT%H:%M:%S%z'):
         target_time = self._time_slice_epoch(earliest, latest, count, slices)
         return self._convert_epoch_formatted(target_time, date_format)
 
@@ -173,7 +177,7 @@ class JinjaGenerator(GeneratorPlugin):
             raise Exception("Unable to process target count style: %s".format(self.jinja_count_type))
 
     def gen(self, count, earliest, latest, samplename=None):
-        #TODO: Figure out how to gracefully tell generator plugins to exit when there is an error.
+        # TODO: Figure out how to gracefully tell generator plugins to exit when there is an error.
         try:
             from jinja2 import Environment, FileSystemLoader
             self.target_count = count
@@ -186,20 +190,34 @@ class JinjaGenerator(GeneratorPlugin):
                 if self._sample.jinja_count_type in ["line_count", "cycles", "perDayVolume"]:
                     self.jinja_count_type = self._sample.jinja_count_type
             startTime = datetime.datetime.now()
-            working_dir, working_config_file = os.path.split(self.config.configfile)
+
+            # if eventgen is running as Splunk app the configfile is None
+            if self.config.configfile:
+                working_dir, working_config_file = os.path.split(self.config.configfile)
+            else:
+                splunk_home = os.environ["SPLUNK_HOME"]
+                app_name = getattr(self._sample, 'app', 'SA-Eventgen')
+                working_dir = os.path.join(splunk_home, 'etc', 'apps', app_name, 'default')
+
             if not hasattr(self._sample, "jinja_template_dir"):
-                template_dir = "templates"
+                template_dir = os.path.join(os.path.dirname(working_dir), 'samples', 'templates')
             else:
                 template_dir = self._sample.jinja_template_dir
-            target_template_dir = os.path.join(working_dir, template_dir)
+
+            if not os.path.isabs(template_dir):
+                target_template_dir = os.path.join(working_dir, template_dir)
+            else:
+                target_template_dir = template_dir
+
             if not hasattr(self._sample, "jinja_target_template"):
                 raise CantFindTemplate("Template to load not specified in eventgen conf for stanza.  Skipping Stanza")
             jinja_env = Environment(
-                loader=FileSystemLoader([target_template_dir, working_dir, template_dir], encoding='utf-8',  followlinks=False),
-                extensions=['jinja2.ext.do', 'jinja2.ext.with_','jinja2.ext.loopcontrols', JinjaTime],
+                loader=FileSystemLoader([target_template_dir, working_dir, template_dir], encoding='utf-8', followlinks=False),
+                extensions=['jinja2.ext.do', 'jinja2.ext.with_', 'jinja2.ext.loopcontrols', JinjaTime],
                 line_statement_prefix="#",
                 line_comment_prefix="##"
             )
+
             jinja_loaded_template = jinja_env.get_template(str(self._sample.jinja_target_template))
             if hasattr(self._sample, 'jinja_variables'):
                 jinja_loaded_vars = json.loads(self._sample.jinja_variables)
@@ -268,6 +286,7 @@ class JinjaGenerator(GeneratorPlugin):
         except Exception as e:
             self.logger.exception(e)
             return 1
+
 
 def load():
     return JinjaGenerator

--- a/splunk_eventgen/splunk_app/README/eventgen.conf.spec
+++ b/splunk_eventgen/splunk_app/README/eventgen.conf.spec
@@ -388,7 +388,19 @@ latest = <time-str>
     * Specifies the latest random time for generated events.
     * If this value is an absolute time, use the dispatch.time_format to format the value.
     * Defaults to now.
-    
+
+#############################
+## JINJA TEMPLATE SETTINGS ##
+#############################
+
+jinja_template_dir = <str>
+    * directory name inside the current eventgen.conf dir where jinja templates can be located.
+    * default template directory is <bundle>/samples/templates if not defined.
+jinja_target_template = <str>
+    * root template to load for all sample generation.
+jinja_variables = <json>
+    * json value that contains a dict of kv pairs to pass as options to load inside of the jinja templating engine.
+
 ################################
 ## TOKEN REPLACEMENT SETTINGS ##
 ################################

--- a/tests/medium/plugins/test_jinja_generator.py
+++ b/tests/medium/plugins/test_jinja_generator.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from mock import patch
+from splunk_eventgen.__main__ import parse_args
+from splunk_eventgen.eventgen_core import EventGenerator
+
+FILE_DIR = os.path.dirname(os.path.abspath(__file__))
+OUTPUT_FILE = 'test_jinja_generator_file_output.result'
+
+
+class TestJinjaGenerator(object):
+
+    def test_jinja_generator_to_file(self):
+        configfile = "tests/sample_eventgen_conf/jinja/eventgen.conf.jinja_basic"
+        testargs = ["eventgen", "generate", configfile]
+        file_output_path = os.path.abspath(os.path.join(FILE_DIR, '..', '..', '..', OUTPUT_FILE))
+        # remove the result file if it exists
+        if os.path.exists(file_output_path):
+            os.remove(file_output_path)
+
+        with patch.object(sys, 'argv', testargs):
+            pargs = parse_args()
+            assert pargs.subcommand == 'generate'
+            assert pargs.configfile == configfile
+            eventgen = EventGenerator(args=pargs)
+            eventgen.start()
+
+        assert os.path.isfile(file_output_path)
+
+        with open(file_output_path, 'r') as outfile:
+            line_count = 1
+            for output_line in outfile:
+                if not output_line or line_count == 11:
+                    break
+                assert "I like little windbags" in output_line
+                assert "Im at: {0} out of: 10".format(line_count) in output_line
+                line_count += 1

--- a/tests/sample_eventgen_conf/jinja/eventgen.conf.jinja_basic
+++ b/tests/sample_eventgen_conf/jinja/eventgen.conf.jinja_basic
@@ -1,0 +1,11 @@
+[Test_Jinja]
+end = 1
+count = 1
+generator = jinja
+jinja_template_dir = templates
+jinja_target_template = test_jinja_basic.template
+jinja_variables = {"large_number":10}
+earliest = -3s
+latest = now
+outputMode = file
+fileName = test_jinja_generator_file_output.result

--- a/tests/sample_eventgen_conf/jinja/templates/test_jinja_basic.template
+++ b/tests/sample_eventgen_conf/jinja/templates/test_jinja_basic.template
@@ -1,0 +1,4 @@
+{% for _ in range(0, large_number) %}
+{%- time_now -%}
+        {"_time":"{{ time_now_epoch }}", "_raw":"{{ time_now_formatted }}  I like little windbags. Im at: {{ loop.index }} out of: {{ large_number }}"}
+{% endfor %}


### PR DESCRIPTION
1. Fix error "AttributeError: 'NoneType' object has no attribute 'rfind'" when using jinja template under SA-Eventgen app.
2. Fix conf checking error  when starting Splunk for the jinja template settings.
3. Add document to address the permission issue: https://github.com/splunk/eventgen/issues/77
4. Fix a few typos.