### PR TITLE
Windbag generator/count + end=0 edge cases

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -323,6 +323,7 @@ count = <integer>
     * Maximum number of events to generate per sample file
     * -1 means replay the entire sample.
     * Defaults to -1.
+    * When used with the windbag generator, the event count is decided by the sample size
 
 perDayVolume = <float>
     * This is used in place of count.  The perDayVolume is a size supplied in GB per Day.  This value will allow

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -320,10 +320,10 @@ backfillSearchUrl = <url>
       in a cluster.
     
 count = <integer>
-    * Maximum number of events to generate per sample file
+    * Maximum number of events to generate per sample file (only used with sample mode).
     * -1 means replay the entire sample.
     * Defaults to -1.
-    * When used with the windbag generator, the event count is decided by the sample size
+    * When count is -1 and the default generator is used, count depends on the size of the sample.
 
 perDayVolume = <float>
     * This is used in place of count.  The perDayVolume is a size supplied in GB per Day.  This value will allow

--- a/splunk_eventgen/lib/eventgentimer.py
+++ b/splunk_eventgen/lib/eventgentimer.py
@@ -37,6 +37,7 @@ class Timer(object):
         self.time = time
         self.stopping = False
         self.countdown = 0
+        self.executions = 0
         self.interval = getattr(self.sample, "interval", config.interval)
         #enable the logger
         self._setup_logging()
@@ -101,10 +102,12 @@ class Timer(object):
 
         self.logger.debug("Timer creating plugin for '%s'" % self.sample.name)
 
-        self.executions = 0
         end = False
         previous_count_left = 0
         raw_event_size = self.predict_event_size()
+        if self.end and int(self.end) == 0:
+            self.logger.info("End = 0, no events will be generated for sample '%s'" % self.sample.name)
+            end = True
         while not end:
             # Need to be able to stop threads by the main thread or this thread. self.config will stop all threads
             # referenced in the config object, while, self.stopping will only stop this one.

--- a/splunk_eventgen/lib/plugins/generator/windbag.py
+++ b/splunk_eventgen/lib/plugins/generator/windbag.py
@@ -9,7 +9,7 @@ class WindbagGenerator(GeneratorPlugin):
 
     def gen(self, count, earliest, latest, samplename=None):
         if count < 0:
-            self.logger.warn('count=-1 specified for windbag generator, defaulting to 60 events/interval')
+            self.logger.warn('Sample size not found for count=-1 and generator=windbag, defaulting to count=60')
             count = 60
         time_interval = timedelta.total_seconds((latest - earliest)) / count
         for i in xrange(count):

--- a/splunk_eventgen/lib/plugins/generator/windbag.py
+++ b/splunk_eventgen/lib/plugins/generator/windbag.py
@@ -8,7 +8,9 @@ class WindbagGenerator(GeneratorPlugin):
         GeneratorPlugin.__init__(self, sample)
 
     def gen(self, count, earliest, latest, samplename=None):
-        # print type(latest - earliest).total_seconds()
+        if count < 0:
+            self.logger.warn('count=-1 specified for windbag generator, defaulting to 60 events/interval')
+            count = 60
         time_interval = timedelta.total_seconds((latest - earliest)) / count
         for i in xrange(count):
             current_time_object = earliest + datetime.timedelta(0, time_interval*(i+1))

--- a/splunk_eventgen/lib/plugins/generator/windbag.py
+++ b/splunk_eventgen/lib/plugins/generator/windbag.py
@@ -1,7 +1,6 @@
 from __future__ import division
 from generatorplugin import GeneratorPlugin
-import logging
-import datetime, time
+import datetime
 from datetime import timedelta
 
 class WindbagGenerator(GeneratorPlugin):

--- a/splunk_eventgen/lib/plugins/rater/config.py
+++ b/splunk_eventgen/lib/plugins/rater/config.py
@@ -3,6 +3,7 @@ import logging
 import logging.handlers
 import datetime
 import random
+import os
 
 
 class ConfigRater(object):
@@ -44,6 +45,11 @@ class ConfigRater(object):
     def rate(self):
         self._sample.count = int(self._sample.count)
         if self._sample.count == -1:
+            # Load the windbag sample by default if we don't have any sample events, allows for a valid count
+            if not self._sample.sampleDict and self._sample.generator == 'windbag':
+                self._sample.name = 'windbag'
+                self._sample.filePath = os.path.join(self._sample.sampleDir, self._sample.name)
+                self._sample.loadSample()
             self._sample.count = len(self._sample.sampleDict)
         self._generatorWorkers = int(self._generatorWorkers)
         count = self._sample.count/self._generatorWorkers

--- a/splunk_eventgen/lib/plugins/rater/config.py
+++ b/splunk_eventgen/lib/plugins/rater/config.py
@@ -44,12 +44,10 @@ class ConfigRater(object):
 
     def rate(self):
         self._sample.count = int(self._sample.count)
-        if self._sample.count == -1:
-            # Load the windbag sample by default if we don't have any sample events, allows for a valid count
-            if not self._sample.sampleDict and self._sample.generator == 'windbag':
-                self._sample.name = 'windbag'
-                self._sample.filePath = os.path.join(self._sample.sampleDir, self._sample.name)
-                self._sample.loadSample()
+        # Let generators handle infinite count for themselves
+        if self._sample.count == -1 and self._sample.generator == 'default':
+            if not self._sample.sampleDict:
+                self.logger.error('No sample found for default generator, cannot generate events')
             self._sample.count = len(self._sample.sampleDict)
         self._generatorWorkers = int(self._generatorWorkers)
         count = self._sample.count/self._generatorWorkers

--- a/tests/perf/eventgen.conf.test1
+++ b/tests/perf/eventgen.conf.test1
@@ -1,16 +1,13 @@
-[blahblah]
+[windbag]
 sampleDir = splunk_eventgen/samples
-interval = 5
 generator = windbag
-outputMode = stdout
-#httpeventServers = {"servers":[{ "protocol":"https", "address":"<enter-ip-address>", "port":"<enter-port>", "key":"<enter-http-key>"}]}
-#index = eg
-#sourcetype = eventgen-6
-#source = eg6.log
+outputMode = httpevent
+httpeventServers = {"servers":[{ "protocol":"https", "address":"<enter-ip-address>", "port":"<enter-port>", "key":"<enter-http-key>"}]}
+index = eg
+sourcetype = eventgen-6
+source = eg6.log
 host = localhost
-#threading = process
-end = 0
-count = 10
+threading = process
 
 # Increase the perDayVolume until the output queue backs up
-#perDayVolume = <GB/day>
+perDayVolume = <GB/day>

--- a/tests/perf/eventgen.conf.test1
+++ b/tests/perf/eventgen.conf.test1
@@ -1,13 +1,16 @@
-[windbag]
+[blahblah]
 sampleDir = splunk_eventgen/samples
+interval = 5
 generator = windbag
-outputMode = httpevent
-httpeventServers = {"servers":[{ "protocol":"https", "address":"<enter-ip-address>", "port":"<enter-port>", "key":"<enter-http-key>"}]}
-index = eg
-sourcetype = eventgen-6
-source = eg6.log
+outputMode = stdout
+#httpeventServers = {"servers":[{ "protocol":"https", "address":"<enter-ip-address>", "port":"<enter-port>", "key":"<enter-http-key>"}]}
+#index = eg
+#sourcetype = eventgen-6
+#source = eg6.log
 host = localhost
-threading = process
+#threading = process
+end = 0
+count = 10
 
 # Increase the perDayVolume until the output queue backs up
-perDayVolume = <GB/day>
+#perDayVolume = <GB/day>

--- a/tests/sample_eventgen_conf/replay/eventgen.conf.replay
+++ b/tests/sample_eventgen_conf/replay/eventgen.conf.replay
@@ -1,13 +1,8 @@
 [replay]
 sampleDir = tests/sample_eventgen_conf/replay
-timeMultiple = 1
 backfill = -5s
 sampletype = raw
 outputMode = stdout
-index = main
-sourcetype = windbag
-source = windbag.log
-host = localhost
 end = 1
 mode = replay
 


### PR DESCRIPTION
Patching up some edge cases that I discovered. End = 0 was generating a single interval of events, but it shouldn't generate any now. There is still no default for end, which is what causes it to run indefinitely.
There was also an issue with the windbag generator and count = -1. Since the generator does not use a sample directly, there is no telling what count should actually represent. We will now load the 'windbag' sample if we're using the generator and haven't found any sample yet. This allows count = -1 to continue to rely on the sample size. If users want a specific number of windbag events per interval, count will still work perfectly fine.