### PR TITLE
add extendIndexes feature

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -210,10 +210,10 @@ index = <index>
     * ONLY VALID WITH outputMode SPLUNKSTREAM
     * Splunk index to write events to. Defaults to main if none specified.
     
-extendIndexes = <index_prefix>:<num>,<index2>,<index3>
+extendIndexes = <index_prefix>:<weight>,<index2>,<index3>
     * Sample level setting. Use this setting enable eventgen to generate multi indexes for one sample. 
-    * if you set the value with pattern like "<index_prefix>:<num>", it will treat <index_prefix> as a prefix of an actual index, 
-    * and <num> is the count of index you want to extend for this sample.
+    * if you set the value with pattern like "<index_prefix>:<weight>", it will treat <index_prefix> as a prefix of an actual index, 
+    * and <weight> is an integer that indicate the count of index you want to extend for this sample.
     * eg: events from a sample with "extendIndexes = test_:5, main, web" setting will be added with indexes "test_0, test_1, 
     * test_2, test_3, test_4, main, web" randomly.
     

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -210,6 +210,12 @@ index = <index>
     * ONLY VALID WITH outputMode SPLUNKSTREAM
     * Splunk index to write events to. Defaults to main if none specified.
     
+extendIndexes = <index>:<num>
+    * Sample level setting. Use this setting enable eventgen to generate multi indexes for one sample. 
+    * <index> is the prefix of actual index, and <num> is the count of index you want to extend for this sample.
+    * eg: events from a sample with "extendIndexes = test_:5" setting will be added with indexes "test_0, test_1, 
+    * test_2, test_3, test_4" randomly.
+    
 source = <source>
     * Valid with outputMode=modinput (default) & outputMode=splunkstream & outputMode=httpevent
     * Set event source in Splunk to <source>. Defaults to 'eventgen' if none specified.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -210,11 +210,12 @@ index = <index>
     * ONLY VALID WITH outputMode SPLUNKSTREAM
     * Splunk index to write events to. Defaults to main if none specified.
     
-extendIndexes = <index>:<num>
+extendIndexes = <index_prefix>:<num>,<index2>,<index3>
     * Sample level setting. Use this setting enable eventgen to generate multi indexes for one sample. 
-    * <index> is the prefix of actual index, and <num> is the count of index you want to extend for this sample.
-    * eg: events from a sample with "extendIndexes = test_:5" setting will be added with indexes "test_0, test_1, 
-    * test_2, test_3, test_4" randomly.
+    * if you set the value with pattern like "<index_prefix>:<num>", it will treat <index_prefix> as a prefix of an actual index, 
+    * and <num> is the count of index you want to extend for this sample.
+    * eg: events from a sample with "extendIndexes = test_:5, main, web" setting will be added with indexes "test_0, test_1, 
+    * test_2, test_3, test_4, main, web" randomly.
     
 source = <source>
     * Valid with outputMode=modinput (default) & outputMode=splunkstream & outputMode=httpevent

--- a/splunk_eventgen/lib/eventgenconfig.py
+++ b/splunk_eventgen/lib/eventgenconfig.py
@@ -30,7 +30,6 @@ from eventgentoken import Token
 
 STANDALONE = False
 
-
 # 5/10/12 CS Some people consider Singleton to be lazy.  Dunno, I like it for convenience.
 # My general thought on that sort of stuff is if you don't like it, reimplement it.  I'll consider
 # your patch.
@@ -77,17 +76,17 @@ class Config(object):
     generatorQueue = None
     args = None
 
-    # Validations
-    _validSettings = [
-        'disabled', 'blacklist', 'spoolDir', 'spoolFile', 'breaker', 'sampletype', 'interval', 'delay', 'count',
-        'bundlelines', 'earliest', 'latest', 'eai:acl', 'hourOfDayRate', 'dayOfWeekRate', 'randomizeCount',
-        'randomizeEvents', 'outputMode', 'fileName', 'fileMaxBytes', 'fileBackupFiles', 'index', 'source', 'sourcetype',
-        'host', 'hostRegex', 'projectID', 'accessToken', 'mode', 'backfill', 'backfillSearch', 'eai:userName',
-        'eai:appName', 'timeMultiple', 'debug', 'minuteOfHourRate', 'timezone', 'dayOfMonthRate', 'monthOfYearRate',
-        'perDayVolume', 'outputWorkers', 'generator', 'rater', 'generatorWorkers', 'timeField', 'sampleDir',
-        'threading', 'profiler', 'maxIntervalsBeforeFlush', 'maxQueueLength', 'splunkMethod', 'splunkPort', 'verbosity',
-        'useOutputQueue', 'seed', 'end', 'autotimestamps', 'autotimestamp', 'httpeventWaitResponse', 'outputCounter',
-        'sequentialTimestamp']
+    ## Validations
+    _validSettings = ['disabled', 'blacklist', 'spoolDir', 'spoolFile', 'breaker', 'sampletype' , 'interval',
+                    'delay', 'count', 'bundlelines', 'earliest', 'latest', 'eai:acl', 'hourOfDayRate',
+                    'dayOfWeekRate', 'randomizeCount', 'randomizeEvents', 'outputMode', 'fileName', 'fileMaxBytes',
+                    'fileBackupFiles', 'index', 'source', 'sourcetype', 'host', 'hostRegex', 'projectID', 'accessToken',
+                    'mode', 'backfill', 'backfillSearch', 'eai:userName', 'eai:appName', 'timeMultiple', 'debug',
+                    'minuteOfHourRate', 'timezone', 'dayOfMonthRate', 'monthOfYearRate', 'perDayVolume',
+                    'outputWorkers', 'generator', 'rater', 'generatorWorkers', 'timeField', 'sampleDir', 'threading',
+                    'profiler', 'maxIntervalsBeforeFlush', 'maxQueueLength', 'splunkMethod', 'splunkPort',
+                    'verbosity', 'useOutputQueue', 'seed','end', 'autotimestamps', 'autotimestamp', 'httpeventWaitResponse',
+                    'outputCounter', 'sequentialTimestamp', 'extendIndexes']
     _validTokenTypes = {'token': 0, 'replacementType': 1, 'replacement': 2}
     _validHostTokens = {'token': 0, 'replacement': 1}
     _validReplacementTypes = [

--- a/splunk_eventgen/lib/eventgensamples.py
+++ b/splunk_eventgen/lib/eventgensamples.py
@@ -420,9 +420,14 @@ class Sample(object):
                         self.sampleDict[i]['_raw'] += '\n'
         if self.extendIndexes:
             try:
-                extend_indexes_count = int(self.extendIndexes.split(':')[-1])
-                extend_indexes_prefix = self.extendIndexes.split(':')[0] + "{}"
-                self.index_list = [ extend_indexes_prefix.format(_i)  for _i in range(extend_indexes_count)]
+                for index_item in self.extendIndexes.split(','):
+                    index_item = index_item.strip()
+                    if ':' in index_item:
+                        extend_indexes_count = int(index_item.split(':')[-1])
+                        extend_indexes_prefix = index_item.split(':')[0] + "{}"
+                        self.index_list.extend([extend_indexes_prefix.format(_i) for _i in range(extend_indexes_count)])
+                    elif len(index_item):
+                        self.index_list.append(index_item)
             except Exception:
                 self.logger.error("Failed to parse extendIndexes, using index={} now.".format(self.index))
                 self.index_list = []

--- a/splunk_eventgen/lib/eventgensamples.py
+++ b/splunk_eventgen/lib/eventgensamples.py
@@ -86,6 +86,8 @@ class Sample(object):
     end = None
     queueable = None
     autotimestamp = None
+    extendIndexes = None
+    index_list = []
 
     # Internal fields
     sampleLines = None
@@ -416,6 +418,15 @@ class Sample(object):
                 for i in xrange(0, len(self.sampleDict)):
                     if len(self.sampleDict[i]['_raw']) < 1 or self.sampleDict[i]['_raw'][-1] != '\n':
                         self.sampleDict[i]['_raw'] += '\n'
+        if self.extendIndexes:
+            try:
+                extend_indexes_count = int(self.extendIndexes.split(':')[-1])
+                extend_indexes_prefix = self.extendIndexes.split(':')[0] + "{}"
+                self.index_list = [ extend_indexes_prefix.format(_i)  for _i in range(extend_indexes_count)]
+            except Exception:
+                self.logger.error("Failed to parse extendIndexes, using index={} now.".format(self.index))
+                self.index_list = []
+                self.extendIndexes = None
 
     def get_loaded_sample(self):
         if self.sampletype != 'csv' and os.path.getsize(self.filePath) > 10000000:

--- a/splunk_eventgen/lib/generatorplugin.py
+++ b/splunk_eventgen/lib/generatorplugin.py
@@ -5,6 +5,7 @@ import logging
 import logging.handlers
 import pprint
 import time
+import random
 import urllib
 from xml.dom import minidom
 from xml.parsers.expat import ExpatError
@@ -226,7 +227,7 @@ class GeneratorPlugin(object):
             except Exception:
                 time_val = int(time.mktime(self._sample.now().timetuple()))
             temp_event = {
-                '_raw': event, 'index': targetevent['index'], 'host': host, 'hostRegex': self._sample.hostRegex,
+                '_raw': event, 'index': random.choice(self._sample.index_list)if len(self._sample.index_list) else targetevent['index'], 'host': host, 'hostRegex': self._sample.hostRegex,
                 'source': targetevent['source'], 'sourcetype': targetevent['sourcetype'], '_time': time_val}
             send_events.append(temp_event)
         return send_events

--- a/splunk_eventgen/lib/outputcounter.py
+++ b/splunk_eventgen/lib/outputcounter.py
@@ -26,7 +26,7 @@ class OutputCounter(object):
         self.current_time = timestamp
         self.event_count_1_min = 0
         self.event_size_1_min = 0
-        self.logger.error("Current throughput is {} B/s, {} count/s".format(self.throughput_volume,
+        self.logger.debug("Current throughput is {} B/s, {} count/s".format(self.throughput_volume,
                                                                             self.throughput_count))
 
     def collect(self, event_count, event_size):


### PR DESCRIPTION
This PR is to add an "extendIndexes" setting. We want to use this feature to set more indexes for one kind of event.
Here are things I have done:
1. Add  "extendIndexes" setting for each sample and it will be parsed in eventgensamples.py and then add a "index_list" for sample.
2. Generator will choose a index from index_list randomly if you set value to "extendIndexes".