### PR TITLE
fix an issue that rest exceptions are not properly handled in setup API

### DIFF
--- a/splunk_eventgen/eventgen_nameko_server.py
+++ b/splunk_eventgen/eventgen_nameko_server.py
@@ -357,12 +357,17 @@ Output Queue Status: {7}\n'''
                     formatted_hostname = socket.gethostbyname(host)
                     if new_key:
                         key = create_new_hec_key(formatted_hostname)
-
-                    self.discovered_servers.append({
-                        "protocol": str(protocol), "address": str(formatted_hostname), "port": str(hec_port), "key":
-                        str(key)})
-                except socket.gaierror:
+                except (socket.gaierror, requests.ConnectionError):
+                    self.log.warning('failed to reach %s, skip...' % host)
                     continue
+                except (ValueError, KeyError):
+                    self.log.warning('failed to setup hec token for %s, skip...' % host)
+                    continue
+
+                self.discovered_servers.append({"protocol": str(protocol),
+                                                    "address": str(formatted_hostname),
+                                                    "port": str(hec_port),
+                                                    "key": str(key)})
 
             counter = 1
             while True:
@@ -395,7 +400,7 @@ Output Queue Status: {7}\n'''
 
             return self.get_conf()
         except Exception as e:
-            self.log.exception(e)
+            self.log.exception(str(e))
             return '500', "Exception: {}".format(e.message)
 
     def get_volume(self):


### PR DESCRIPTION
When setup eventgen with 200+ indexers, any exceptions will terminate setup, thus default configure file is not re-written with indexers information.