### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# The Splunk Event Generator
+# Splunk Event Generator (Eventgen)
 
 ### Status
 [![CircleCI](https://circleci.com/gh/splunk/eventgen/tree/develop.svg?style=svg)](https://circleci.com/gh/splunk/eventgen/tree/develop)
 
-### Intro
+### Introduction
 
-The Splunk Event Generator is a utility which allows its user to easily build real-time event generators.
+Splunk Event Generator is a utility that helps users easily build real-time event generators.
 The current maintainers of this project are Brian Bingham (bbingham@splunk.com), Tony Lee (tonyl@splunk.com), and Jack Meixensperger (jackm@splunk.com).
 
 The goals of this project:
 
-* Eliminate the need for hand coded event generators in Splunk apps
+* Eliminate the need for hand-coded event generators in Splunk apps
 * Allow for portability of event generators between applications and allow templates to be quickly adapted between use cases
-* Allow every type of event or transaction to be modeled inside Eventgen
+* Allow every type of events or transactions to be modeled inside Eventgen
 
 ### Downloading a Splunk Eventgen App
 
@@ -28,7 +28,7 @@ Please note [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### License
 
-The Splunk Event Generator is licensed under the Apache License 2.0. Details can be found in the [LICENSE](LICENSE) file.
+Splunk Event Generator is licensed under the Apache License 2.0. Details can be found in the [LICENSE](LICENSE) file.
 
 ### Support
 


### PR DESCRIPTION
Like other Splunk products - Splunk Enterprise Security, Splunk Business Workflow ... - Splunk Event Generator does not need a definitive article "The" before the product name.