### PR TITLE
Clean up and interval error

### DIFF
--- a/splunk_eventgen/lib/eventgenoutput.py
+++ b/splunk_eventgen/lib/eventgenoutput.py
@@ -124,14 +124,12 @@ class Output(object):
                 except Full:
                     self.logger.warning("Output Queue full, looping again")
             else:
-                tmp = [len(s['_raw']) for s in q]
-                # TODO: clean out eventsSend and bytesSent if they are not being used in config
-                # self.config.eventsSent.add(len(tmp))
-                # self.config.bytesSent.add(sum(tmp))
-                if self.config.splunkEmbedded and len(tmp) > 0:
-                    metrics = logging.getLogger('eventgen_metrics')
-                    metrics.info({
-                        'timestamp': datetime.datetime.strftime(datetime.datetime.now(), '%Y-%m-%d %H:%M:%S'), 'sample':
-                        self._sample.name, 'events': len(tmp), 'bytes': sum(tmp)})
-                tmp = None
+                if self.config.splunkEmbedded:
+                    tmp = [len(s['_raw']) for s in q]
+                    if len(tmp) > 0:
+                        metrics = logging.getLogger('eventgen_metrics')
+                        metrics.info({
+                            'timestamp': datetime.datetime.strftime(datetime.datetime.now(), '%Y-%m-%d %H:%M:%S'), 'sample':
+                            self._sample.name, 'events': len(tmp), 'bytes': sum(tmp)})
+                    tmp = None
                 outputer.run()

--- a/splunk_eventgen/lib/plugins/generator/default.py
+++ b/splunk_eventgen/lib/plugins/generator/default.py
@@ -67,6 +67,5 @@ class DefaultGenerator(GeneratorPlugin):
 
         GeneratorPlugin.build_events(self, eventsDict, startTime, earliest, latest)
 
-
 def load():
     return DefaultGenerator


### PR DESCRIPTION
It is ok to go over the interval time when end == 1 because the generation is not bound by the interval.

Also moving execution "tmp = [len(s['_raw']) for s in q]" inside of the conditional so remove unnecessary execution when it isn't Splunk Embedded mode.