### PR TITLE
fixed bug #269

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test_helper:
 
 	sleep 120
 	@echo 'Provision splunk container'
-	docker-compose -f tests/large/provision/docker-compose.yml exec -T splunk sh -c 'cd /opt/splunk;./provision.sh;/opt/splunk/bin/splunk enable listen 9997 -auth admin:changeme;/opt/splunk/bin/splunk restart'
+	docker-compose -f tests/large/provision/docker-compose.yml exec -T splunk sh -c 'cd /opt/splunk;./provision.sh;/opt/splunk/bin/splunk enable listen 9997 -auth admin:changeme;/opt/splunk/bin/splunk add index test_0;/opt/splunk/bin/splunk add index test_1;/opt/splunk/bin/splunk restart'
 
 run_tests:
 	@echo 'Running the super awesome tests'

--- a/splunk_eventgen/lib/eventgensamples.py
+++ b/splunk_eventgen/lib/eventgensamples.py
@@ -85,8 +85,7 @@ class Sample(object):
     end = None
     queueable = None
     autotimestamp = None
-    extendIndexes = None
-    index_list = []
+    extendIndexes = []
 
     # Internal fields
     sampleLines = None
@@ -400,23 +399,21 @@ class Sample(object):
                 for i in xrange(0, len(self.sampleDict)):
                     if len(self.sampleDict[i]['_raw']) < 1 or self.sampleDict[i]['_raw'][-1] != '\n':
                         self.sampleDict[i]['_raw'] += '\n'
-        if self.extendIndexes:
+        if type(self.extendIndexes) is not list and len(self.extendIndexes):
             try:
+                index_list = []
                 for index_item in self.extendIndexes.split(','):
                     index_item = index_item.strip()
                     if ':' in index_item:
                         extend_indexes_count = int(index_item.split(':')[-1])
                         extend_indexes_prefix = index_item.split(':')[0] + "{}"
-                        self.index_list.extend([extend_indexes_prefix.format(_i) for _i in range(extend_indexes_count)])
+                        index_list.extend([extend_indexes_prefix.format(_i) for _i in range(extend_indexes_count)])
                     elif len(index_item):
-                        self.index_list.append(index_item)
+                        index_list.append(index_item)
+                self.extendIndexes = index_list
             except Exception:
                 logger.error("Failed to parse extendIndexes, using index={} now.".format(self.index))
-                self.index_list = []
-            finally:
-                # only read the extendIndexes configure once.
-                self.extendIndexes = None
-
+                self.extendIndexes = []
     def get_loaded_sample(self):
         if self.sampletype != 'csv' and os.path.getsize(self.filePath) > 10000000:
             self._openSampleFile()

--- a/splunk_eventgen/lib/eventgensamples.py
+++ b/splunk_eventgen/lib/eventgensamples.py
@@ -85,7 +85,7 @@ class Sample(object):
     end = None
     queueable = None
     autotimestamp = None
-    extendIndexes = []
+    extendIndexes = None
 
     # Internal fields
     sampleLines = None
@@ -102,6 +102,7 @@ class Sample(object):
         self.name = name
         self.tokens = []
         self._lockedSettings = []
+        self.index_list = []
         self.backfilldone = False
 
     def updateConfig(self, config):
@@ -399,21 +400,23 @@ class Sample(object):
                 for i in xrange(0, len(self.sampleDict)):
                     if len(self.sampleDict[i]['_raw']) < 1 or self.sampleDict[i]['_raw'][-1] != '\n':
                         self.sampleDict[i]['_raw'] += '\n'
-        if type(self.extendIndexes) is not list and len(self.extendIndexes):
+        if self.extendIndexes:
             try:
-                index_list = []
                 for index_item in self.extendIndexes.split(','):
                     index_item = index_item.strip()
                     if ':' in index_item:
                         extend_indexes_count = int(index_item.split(':')[-1])
                         extend_indexes_prefix = index_item.split(':')[0] + "{}"
-                        index_list.extend([extend_indexes_prefix.format(_i) for _i in range(extend_indexes_count)])
+                        self.index_list.extend([extend_indexes_prefix.format(_i) for _i in range(extend_indexes_count)])
                     elif len(index_item):
-                        index_list.append(index_item)
-                self.extendIndexes = index_list
+                        self.index_list.append(index_item)
             except Exception:
                 logger.error("Failed to parse extendIndexes, using index={} now.".format(self.index))
-                self.extendIndexes = []
+                self.index_list = []
+            finally:
+                # only read the extendIndexes configure once.
+                self.extendIndexes = None
+
     def get_loaded_sample(self):
         if self.sampletype != 'csv' and os.path.getsize(self.filePath) > 10000000:
             self._openSampleFile()

--- a/splunk_eventgen/lib/generatorplugin.py
+++ b/splunk_eventgen/lib/generatorplugin.py
@@ -178,7 +178,7 @@ class GeneratorPlugin(object):
         total_count = len(eventsDict)
         index = None
         if total_count > 0:
-            index = random.choice(self._sample.extendIndexes) if len(self._sample.extendIndexes) else eventsDict[0]['index']
+            index = random.choice(self._sample.index_list) if len(self._sample.index_list) else eventsDict[0]['index']
         for targetevent in eventsDict:
             event = targetevent["_raw"]
             # Maintain state for every token in a given event, Hash contains keys for each file name which is

--- a/splunk_eventgen/lib/generatorplugin.py
+++ b/splunk_eventgen/lib/generatorplugin.py
@@ -178,7 +178,7 @@ class GeneratorPlugin(object):
         total_count = len(eventsDict)
         index = None
         if total_count > 0:
-            index = random.choice(self._sample.index_list) if len(self._sample.index_list) else eventsDict[0]['index']
+            index = random.choice(self._sample.extendIndexes) if len(self._sample.extendIndexes) else eventsDict[0]['index']
         for targetevent in eventsDict:
             event = targetevent["_raw"]
             # Maintain state for every token in a given event, Hash contains keys for each file name which is

--- a/tests/large/conf/eventgen_extend_index.conf
+++ b/tests/large/conf/eventgen_extend_index.conf
@@ -1,0 +1,38 @@
+[cisco]
+sampleDir = ../sample
+mode = sample
+sampletype = raw
+outputMode = httpevent
+httpeventServers = {"servers": [{"protocol": "https", "port": "8088", "key": "00000000-0000-0000-0000-000000000000", "address": "localhost"}]}
+end = 1
+sourcetype = cisco
+index = main
+
+token.0.token = \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}
+token.0.replacementType = timestamp
+token.0.replacement = %Y-%m-%d %H:%M:%S
+
+token.1.token = @@integer
+token.1.replacementType = random
+token.1.replacement = integer[0:10]
+
+
+[sample]
+sampleDir = ../sample
+mode = sample
+sampletype = raw
+outputMode = httpevent
+httpeventServers = {"servers": [{"protocol": "https", "port": "8088", "key": "00000000-0000-0000-0000-000000000000", "address": "localhost"}]}
+end = 1
+sourcetype = syslog
+extendIndexes = test_:2
+
+token.0.token = \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}
+token.0.replacementType = timestamp
+token.0.replacement = %Y-%m-%d %H:%M:%S
+
+token.1.token = @@integer
+token.1.replacementType = random
+token.1.replacement = integer[0:10]
+
+

--- a/tests/large/sample/cisco
+++ b/tests/large/sample/cisco
@@ -1,0 +1,12 @@
+2014-01-04 20:00:00 WINDBAG Event 1 of 12 randint @@integer
+2014-01-04 20:00:01 WINDBAG Event 2 of 12 randint @@integer
+2014-01-04 20:00:02 WINDBAG Event 3 of 12 randint @@integer
+2014-01-04 20:00:03 WINDBAG Event 4 of 12 randint @@integer
+2014-01-04 20:00:03 WINDBAG Event 5 of 12 randint @@integer
+2014-01-04 20:00:04 WINDBAG Event 6 of 12 randint @@integer
+2014-01-04 20:00:05 WINDBAG Event 7 of 12 randint @@integer
+2014-01-04 20:00:06 WINDBAG Event 8 of 12 randint @@integer
+2014-01-04 20:00:08 WINDBAG Event 9 of 12 randint @@integer
+2014-01-04 20:00:20 WINDBAG Event 10 of 12 randint @@integer
+2014-01-04 20:00:21 WINDBAG Event 11 of 12 randint @@integer
+2014-01-04 20:00:21 WINDBAG Event 12 of 12 randint @@integer

--- a/tests/large/test_extend_index.py
+++ b/tests/large/test_extend_index.py
@@ -1,0 +1,14 @@
+from utils.splunk_search_util import get_session_key, preprocess_search, run_search, get_search_response
+
+
+def test_extend_index(eventgen_test_helper):
+    """Test extendIndexes config"""
+    eventgen_test_helper("eventgen_extend_index.conf").get_events()
+
+    session_key = get_session_key()
+    search_job_id = run_search(session_key, preprocess_search('index=main sourcetype=cisco'))
+    test_index_search_job_id = run_search(session_key, preprocess_search('index=test_*'))
+    main_events = get_search_response(session_key, search_job_id)
+    test_index_events = get_search_response(session_key, test_index_search_job_id)
+    assert len(main_events) == 12
+    assert len(test_index_events) == 12


### PR DESCRIPTION
When I debug on this bug, I saw the variable `index_list` in eventgesamples.py was shared by each sample, which is not make sense(each sample should keep a new one). 
Then I just put the parse result into the "extendIndexes" and it fixed that bug. https://github.com/splunk/eventgen/issues/269.