### PR TITLE
[global] perDayVolume

### DIFF
--- a/splunk_eventgen/eventgen_api_server/eventgen_server_api.py
+++ b/splunk_eventgen/eventgen_api_server/eventgen_server_api.py
@@ -371,7 +371,7 @@ class EventgenServerAPI():
                 stanza_num -= 1
             divided_volume = float(target_volume) / stanza_num
             for stanza, kv_pair in conf_dict.iteritems():
-                if isinstance(kv_pair, dict) and 'global' not in stanza and '.*' not in stanza:
+                if isinstance(kv_pair, dict) and stanza != 'global' and '.*' not in stanza:
                     conf_dict[stanza]["perDayVolume"] = divided_volume
 
         self.set_conf(conf_dict)

--- a/splunk_eventgen/eventgen_api_server/eventgen_server_api.py
+++ b/splunk_eventgen/eventgen_api_server/eventgen_server_api.py
@@ -371,7 +371,7 @@ class EventgenServerAPI():
                 stanza_num -= 1
             divided_volume = float(target_volume) / stanza_num
             for stanza, kv_pair in conf_dict.iteritems():
-                if isinstance(kv_pair, dict) and stanza != '.*' not in stanza:
+                if isinstance(kv_pair, dict) and 'global' not in stanza and '.*' not in stanza:
                     conf_dict[stanza]["perDayVolume"] = divided_volume
 
         self.set_conf(conf_dict)


### PR DESCRIPTION
We explicitly exclude this stanza from our stanza count when calculating perDayVolume, but we assign the setting the stanza anyways. This results in an inaccurate total perDayVolume when we append the values of each stanza.

My fix will prevent us from assigning the setting to the stanza to mirror how we count each stanza.