### PR TITLE
Using multiprocess pool to address the OOM issue

### DIFF
--- a/splunk_eventgen/eventgen_api_server/eventgen_server_api.py
+++ b/splunk_eventgen/eventgen_api_server/eventgen_server_api.py
@@ -392,7 +392,7 @@ class EventgenServerAPI():
         response = {}
         if self.eventgen.eventgen_core_object.check_running():
             try:
-                self.eventgen.eventgen_core_object.stop(force_stop=force_stop)
+                self.eventgen.eventgen_core_object.stop()
             except:
                 pass
             response['message'] = "Eventgen is stopped."

--- a/splunk_eventgen/eventgen_core.py
+++ b/splunk_eventgen/eventgen_core.py
@@ -6,9 +6,9 @@ import logging.config
 import os
 import sys
 import time
-import signal
 from Queue import Empty, Queue
 from threading import Thread
+import multiprocessing
 
 from lib.eventgenconfig import Config
 from lib.eventgenexceptions import PluginNotLoaded
@@ -140,7 +140,7 @@ class EventGenerator(object):
         # APPPERF-263: be greedy when scanning plugin dir (eat all the pys)
         self._initializePlugins(plugindir, pluginsdict, plugintype)
 
-    def _setup_pools(self, generator_worker_count):
+    def _setup_pools(self, generator_worker_count=20):
         '''
         This method is an internal method called on init to generate pools needed for processing.
 
@@ -150,7 +150,8 @@ class EventGenerator(object):
         self._create_generator_pool()
         self._create_timer_threadpool()
         self._create_output_threadpool()
-        self._create_generator_workers(generator_worker_count)
+        if self.args.multiprocess:
+            self.pool = multiprocessing.Pool(generator_worker_count, maxtasksperchild=1000000)
 
     def _create_timer_threadpool(self, threadcount=100):
         '''
@@ -162,11 +163,13 @@ class EventGenerator(object):
         '''
         self.sampleQueue = Queue(maxsize=0)
         num_threads = threadcount
+        self.timer_thread_pool = []
         for i in range(num_threads):
             worker = Thread(target=self._worker_do_work, args=(
                 self.sampleQueue,
                 self.loggingQueue,
             ), name="TimeThread{0}".format(i))
+            self.timer_thread_pool.append(worker)
             worker.setDaemon(True)
             worker.start()
 
@@ -185,11 +188,13 @@ class EventGenerator(object):
         else:
             self.outputQueue = Queue(maxsize=500)
         num_threads = threadcount
+        self.output_thread_pool = []
         for i in range(num_threads):
             worker = Thread(target=self._worker_do_work, args=(
                 self.outputQueue,
                 self.loggingQueue,
             ), name="OutputThread{0}".format(i))
+            self.output_thread_pool.append(worker)
             worker.setDaemon(True)
             worker.start()
 
@@ -202,8 +207,7 @@ class EventGenerator(object):
                             has over 10 generators working, additional samples won't run until the first ones end.
         :return:
         '''
-        if  self.args.multiprocess:
-            import multiprocessing
+        if self.args.multiprocess:
             self.manager = multiprocessing.Manager()
             if self.config.disableLoggingQueue:
                 self.loggingQueue = None
@@ -233,22 +237,6 @@ class EventGenerator(object):
                     worker = Thread(target=self._generator_do_work, args=(self.workerQueue, self.loggingQueue, None))
                     worker.setDaemon(True)
                     worker.start()
-
-    def _create_generator_workers(self, workercount=20):
-        if self.args.multiprocess:
-            import multiprocessing
-            self.workerPool = []
-            for worker in xrange(workercount):
-                # builds a list of tuples to use the map function
-                process = multiprocessing.Process(target=self._proc_worker_do_work, args=(
-                    self.workerQueue,
-                    self.loggingQueue,
-                    self.genconfig,
-                ))
-                self.workerPool.append(process)
-                process.start()
-        else:
-            pass
 
     def _setup_loggers(self, args=None):
         self.logger = logger
@@ -292,37 +280,6 @@ class EventGenerator(object):
                     break
                 self.logger.exception(str(e))
                 raise e
-
-    @staticmethod
-    def _proc_worker_do_work(work_queue, logging_queue, config):
-        genconfig = config
-        stopping = genconfig['stopping']
-        root = logging.getLogger()
-        root.setLevel(logging.DEBUG)
-        if logging_queue is not None:
-            # TODO https://github.com/splunk/eventgen/issues/217
-            qh = logutils.queue.QueueHandler(logging_queue)
-            root.addHandler(qh)
-        else:
-            root.addHandler(logging.StreamHandler())
-        while not stopping:
-            try:
-                root.info("Checking for work")
-                item = work_queue.get(timeout=10)
-                item.logger = root
-                item._out.updateConfig(item.config)
-                item.run()
-                work_queue.task_done()
-                stopping = genconfig['stopping']
-                item.logger.debug("Current Worker Stopping: {0}".format(stopping))
-            except Empty:
-                stopping = genconfig['stopping']
-            except Exception as e:
-                root.exception(e)
-                raise e
-        else:
-            root.info("Stopping Process")
-            sys.exit(0)
 
     def logger_thread(self, loggingQueue):
         while not self.stopping:
@@ -426,8 +383,12 @@ class EventGenerator(object):
                 self.logger.info("Creating timer object for sample '%s' in app '%s'" % (s.name, s.app))
                 # This is where the timer is finally sent to a queue to be processed.  Needs to move to this object.
                 try:
-                    t = Timer(1.0, sample=s, config=self.config, genqueue=self.workerQueue,
-                              outputqueue=self.outputQueue, loggingqueue=self.loggingQueue)
+                    if self.args.multiprocess:
+                        t = Timer(1.0, sample=s, config=self.config, genqueue=self.workerQueue,
+                                  outputqueue=self.outputQueue, loggingqueue=self.loggingQueue, pool=self.pool)
+                    else:
+                        t = Timer(1.0, sample=s, config=self.config, genqueue=self.workerQueue,
+                                  outputqueue=self.outputQueue, loggingqueue=self.loggingQueue)
                 except PluginNotLoaded as pnl:
                     self._load_custom_plugins(pnl)
                     t = Timer(1.0, sample=s, config=self.config, genqueue=self.workerQueue,
@@ -460,6 +421,12 @@ class EventGenerator(object):
         self.stopping = True
         self.force_stop = force_stop
 
+        # join timer thread and output thread
+        for output_thread in self.output_thread_pool:
+            output_thread.join()
+        for timer_thread in self.timer_thread_pool:
+            timer_thread.join()
+
         self.logger.info("All timers exited, joining generation queue until it's empty.")
         if force_stop:
             self.logger.info("Forcibly stopping Eventgen: Deleting workerQueue.")
@@ -472,18 +439,9 @@ class EventGenerator(object):
                 self.kill_processes()
             else:
                 self.genconfig["stopping"] = True
-                for worker in self.workerPool:
-                    count = 0
-                    # We wait for a minute until terminating the worker
-                    while worker.exitcode is None and count != 20:
-                        if count == 30:
-                            self.logger.info("Terminating worker {0}".format(worker._name))
-                            worker.terminate()
-                            count = 0
-                            break
-                        self.logger.info("Worker {0} still working, waiting for it to finish.".format(worker._name))
-                        time.sleep(2)
-                        count += 1
+                self.pool.close()
+                self.pool.join()
+
         self.logger.info("All generators working/exited, joining output queue until it's empty.")
         if not self.args.multiprocess and not force_stop:
             self.outputQueue.join()
@@ -531,17 +489,13 @@ class EventGenerator(object):
 
         :return: if eventgen jobs are finished, return True else False
         '''
-        return self.sampleQueue.empty() and self.sampleQueue.unfinished_tasks <= 0 and self.workerQueue.empty() and self.workerQueue.unfinished_tasks <= 0
+        return self.sampleQueue.empty() and self.sampleQueue.unfinished_tasks <= 0 and \
+            self.workerQueue.empty() and self.workerQueue.unfinished_tasks <= 0
 
     def kill_processes(self):
-        try:
-            if self.args.multiprocess:
-                for worker in self.workerPool:
-                    try: os.kill(int(worker.pid), signal.SIGKILL)
-                    except: continue
-                del self.outputQueue
-                self.manager.shutdown()
-        except:
-            pass
-            
-                
+        if self.args.multiprocess and hasattr(self, "pool"):
+            self.pool.close()
+            self.pool.terminate()
+            self.pool.join()
+            del self.outputQueue
+            self.manager.shutdown()

--- a/splunk_eventgen/lib/eventgenoutput.py
+++ b/splunk_eventgen/lib/eventgenoutput.py
@@ -98,6 +98,7 @@ class Output(object):
             outputer = self.outputPlugin(self._sample, self.output_counter)
             outputer.updateConfig(self.config)
             outputer.set_events(q)
+            del q
             # When an outputQueue is used, it needs to run in a single threaded nature which requires to be put back
             # into the outputqueue so a single thread worker can execute it. When an outputQueue is not used, it can be
             # ran by multiple processes or threads. Therefore, no need to put the outputer back into the Queue. Just
@@ -106,6 +107,7 @@ class Output(object):
             if self.outputPlugin.useOutputQueue or self.config.useOutputQueue:
                 try:
                     self.outputQueue.put(outputer)
+                    del outputer
                 except Full:
                     logger.warning("Output Queue full, looping again")
             else:
@@ -117,3 +119,4 @@ class Output(object):
                             self._sample.name, 'events': len(tmp), 'bytes': sum(tmp)})
                     tmp = None
                 outputer.run()
+                del outputer

--- a/splunk_eventgen/lib/eventgenoutput.py
+++ b/splunk_eventgen/lib/eventgenoutput.py
@@ -98,7 +98,6 @@ class Output(object):
             outputer = self.outputPlugin(self._sample, self.output_counter)
             outputer.updateConfig(self.config)
             outputer.set_events(q)
-            del q
             # When an outputQueue is used, it needs to run in a single threaded nature which requires to be put back
             # into the outputqueue so a single thread worker can execute it. When an outputQueue is not used, it can be
             # ran by multiple processes or threads. Therefore, no need to put the outputer back into the Queue. Just
@@ -107,7 +106,6 @@ class Output(object):
             if self.outputPlugin.useOutputQueue or self.config.useOutputQueue:
                 try:
                     self.outputQueue.put(outputer)
-                    del outputer
                 except Full:
                     logger.warning("Output Queue full, looping again")
             else:
@@ -119,4 +117,3 @@ class Output(object):
                             self._sample.name, 'events': len(tmp), 'bytes': sum(tmp)})
                     tmp = None
                 outputer.run()
-                del outputer


### PR DESCRIPTION
Previously, when using `multiprocess` mode with 20 `generatorWorkers`, the process will be killed as `Out of memory` error.

After adopting `pool` with `maxtasksperchild`, the processes are now down for OOM after more than 24 hours. 

Data ingestion with `perdayvolume=600`:
![image](https://user-images.githubusercontent.com/1230626/65666189-b984f180-e06f-11e9-8a34-71f76a9c6aaf.png)

Process status and memory usage:
![image](https://user-images.githubusercontent.com/1230626/65666237-cefa1b80-e06f-11e9-9e29-d28c8d674cc1.png)
