### PR TITLE
Remove workerQueue unfinished tasks

### DIFF
--- a/splunk_eventgen/eventgen_core.py
+++ b/splunk_eventgen/eventgen_core.py
@@ -531,7 +531,7 @@ class EventGenerator(object):
 
         :return: if eventgen jobs are finished, return True else False
         '''
-        return self.sampleQueue.empty() and self.sampleQueue.unfinished_tasks <= 0 and self.workerQueue.empty() and self.workerQueue.unfinished_tasks <= 0
+        return self.sampleQueue.empty() and self.sampleQueue.unfinished_tasks <= 0 and self.workerQueue.empty()
 
     def kill_processes(self):
         try:
@@ -543,5 +543,3 @@ class EventGenerator(object):
                 self.manager.shutdown()
         except:
             pass
-            
-                


### PR DESCRIPTION
Bug found after hitting start endpoint on eg controller. All eg servers cannot retrieve status and produce the following log message:
`{"event": "'JoinableQueue' object has no attribute 'unfinished_tasks'", "level": "error", "timestamp": "2019-10-07T21:45:57.906983Z"}`

After change, eg server is able to retrieve status and still ends execution properly.