### PR TITLE
Fixing api server

### DIFF
--- a/splunk_eventgen/eventgen_api_server/eventgen_core_object.py
+++ b/splunk_eventgen/eventgen_api_server/eventgen_core_object.py
@@ -33,13 +33,11 @@ class EventgenCoreObject():
     def _create_args(self):
         args = argparse.Namespace()
         args.daemon = False
-        args.verbosity = None
         args.version = False
         args.backfill = None
         args.count = None
         args.devnull = False
         args.disableOutputQueue = False
-        args.end = None
         args.generators = None
         args.interval = None
         args.keepoutput = False
@@ -50,7 +48,7 @@ class EventgenCoreObject():
         args.sample = None
         args.version = False
         args.subcommand = 'generate'
-        args.verbosity = 20
+        args.verbosity = 10
         args.wsgi = True
         args.modinput_mode = False
         args.generator_queue_size = 1500

--- a/splunk_eventgen/eventgen_api_server/eventgen_core_object.py
+++ b/splunk_eventgen/eventgen_api_server/eventgen_core_object.py
@@ -48,7 +48,7 @@ class EventgenCoreObject():
         args.sample = None
         args.version = False
         args.subcommand = 'generate'
-        args.verbosity = 10
+        args.verbosity = 20
         args.wsgi = True
         args.modinput_mode = False
         args.generator_queue_size = 1500

--- a/splunk_eventgen/eventgen_api_server/eventgen_server.py
+++ b/splunk_eventgen/eventgen_api_server/eventgen_server.py
@@ -16,7 +16,7 @@ class EventgenServer():
         self.role = 'server'
 
         self.logger = logging.getLogger('eventgen_server')
-        self.logger.info('Initialized Eventgen Controller: hostname [{}]'.format(self.host))
+        self.logger.info('Initialized Eventgen Server: hostname [{}]'.format(self.host))
 
         if self.mode != 'standalone':
             from redis_connector import RedisConnector

--- a/splunk_eventgen/eventgen_api_server/eventgen_server_api.py
+++ b/splunk_eventgen/eventgen_api_server/eventgen_server_api.py
@@ -22,7 +22,7 @@ INTERNAL_ERROR_RESPONSE = json.dumps({"message": "Internal Error Occurred"})
 
 FILE_PATH = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_PATH = os.path.realpath(os.path.join(FILE_PATH, "..", "default"))
-SAMPLE_DIR_PATH = os.path.realpath(os.path.join(FILE_PATH, "..", "samples"))
+SAMPLE_DIR_PATH = os.path.realpath(os.path.join(FILE_PATH, "..", "serverSamples"))
 
 class EventgenServerAPI():
     def __init__(self, eventgen, redis_connector, host, mode='standalone'):
@@ -452,6 +452,8 @@ class EventgenServerAPI():
         bundle_dir = self.unarchive_bundle(self.download_bundle(url))
 
         if os.path.isdir(os.path.join(bundle_dir, "samples")):
+            if not os.path.exists(SAMPLE_DIR_PATH):
+                os.makedirs(SAMPLE_DIR_PATH)
             for file in glob.glob(os.path.join(bundle_dir, "samples", "*")):
                 shutil.copy(file, SAMPLE_DIR_PATH)
             self.logger.info("Copied all samples to the sample directory.")


### PR DESCRIPTION
- Instead of copying bundle sample files into a default eventgen sample directory, this PR will create a new directory and move the sample files. This change is needed because [.*] stanza will try to work with every sample file if we use a default eventgen sample directory.