### PR TITLE
add throughput summary and fix timmer blocked by  end=3 count=0 settings

### DIFF
--- a/splunk_eventgen/lib/eventgentimer.py
+++ b/splunk_eventgen/lib/eventgentimer.py
@@ -176,6 +176,7 @@ class Timer(object):
                             logger.info(
                                 "There is no data to be generated in worker {0} because the count is {1}.".format(
                                     self.sample.config.generatorWorkers, count))
+                            self.executions += 1
                         else:
                             # Spawn workers at the beginning of job rather than wait for next interval
                             logger.info("Starting '%d' generatorWorkers for sample '%s'" %


### PR DESCRIPTION
Here is what I did in this PR:
1. Add Throughput summary when we call "/status" from a controller. (eventgen_controller_api.py)
2. When we have a sample with settings of "count=0, end=3", the timer for that sample will blocked and only log "There is no data to be generated in worker...". because the execution is always 0. We should increase the execution so that this sample timer can finished the job after 3 execution.