### PR TITLE
Revert coverage version to 4.5.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ pytest==4.6.4
 pytest-xdist
 mock
 pytest-cov
+coverage==4.5.4
 docker==3.7.3
 pyOpenSSL
 lxml==4.3.4


### PR DESCRIPTION
Coverage 5.0 is released December 4th but with bug: https://github.com/nedbat/coveragepy/issues/886

Fix the version to 4.5.4 in `requirements.txt`.