### PR TITLE
Fix test case failure cased by new jinja version and update the log config

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -129,7 +129,7 @@ outputMode = scsout | modinput | s2s | file | splunkstream | stdout | devnull | 
     * If setting splunkstream, should set splunkHost, splunkPort, splunkMethod,
       splunkUser and splunkPassword if not Splunk embedded
     * If setting s2s, should set splunkHost and splunkPort
-    * If setting syslogout, should set syslogDestinationHost and syslogDestinationPort
+    * If setting syslogout, should set syslogDestinationHost and syslogDestinationPort. A UDP port listening on Splunk needs to be configured. https://docs.splunk.com/Documentation/Splunk/latest/Data/HowSplunkEnterprisehandlessyslogdata
     * If setting httpevent, should set httpeventServers
     * If setting metric_httpevent, should set httpeventServers and make sure your index is a splunk metric index
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ requests[security]
 ujson>=1.35
 pyyaml
 httplib2
-jinja2
+jinja2==2.10.3
 urllib3==1.24.2
 pyOpenSSL
 flake8>=3.7.7

--- a/splunk_eventgen/lib/logging_config/__init__.py
+++ b/splunk_eventgen/lib/logging_config/__init__.py
@@ -2,7 +2,7 @@ import os
 import logging.config
 
 LOG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'logs')
-DEFAULT_LOGGING_LEVEL = "DEBUG"
+DEFAULT_LOGGING_LEVEL = "ERROR"
 
 LOGGING_CONFIG = {
     'version': 1,
@@ -76,7 +76,7 @@ LOGGING_CONFIG = {
 
     'loggers': {
         'eventgen': {
-            'handlers': ['console', 'eventgen_main'],
+            'handlers': ['eventgen_main'],
             'level': DEFAULT_LOGGING_LEVEL,
             'propagate': False
         },


### PR DESCRIPTION
I have done a few things here in this PR: 
1. Fix the test cases failure caused by new jinja version; (found when preparing the KT session)
2. Remove the config to print log to console as it will regarded as ERROR by Splunk; [Splunk Answers](https://answers.splunk.com/answers/792795/splunk-eventgen-652-folder-structure.html#answer-793817)
3. Change the logging level to ERROR by default;
4. Add `syslog` output plugin extra configuration by Splunk;