### PR TITLE
Add missing documentation for negative floats, as introduced in PR#127

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -323,8 +323,7 @@ Tokens in the default generator can override the sample to allow dynamic content
       and <end> is a number greater than 0 and greater than or equal to <start>. If rated,
       will be multiplied times hourOfDayRate and dayOfWeekRate.
     * For float[<start>:<end>], the token will be replaced with a random float between
-      start and end values where <start> is a number greater than 0
-      and <end> is a number greater than 0 and greater than or equal to <start>.
+      start and end values where <end> is a number greater than or equal to <start>.
       For floating point numbers, precision will be based off the precision specified
       in <start>. For example, if we specify 1.0, precision will be one digit, if we specify
       1.0000, precision will be four digits. If rated, will be multiplied times hourOfDayRate and dayOfWeekRate.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -564,8 +564,7 @@ token.<n>.replacement = <string> | <strptime> | ["list","of","strptime"] | guid 
       and <end> is a number greater than 0 and greater than or equal to <start>.
       If rated, will be multiplied times hourOfDayRate and dayOfWeekRate.
     * For float[<start>:<end>], the token will be replaced with a random float between
-      start and end values where <start> is a number greater than 0
-      and <end> is a number greater than 0 and greater than or equal to <start>.
+      start and end values where <end> is a number greater than or equal to <start>.
       For floating point numbers, precision will be based off the precision specified
       in <start>. For example, if we specify 1.0, precision will be one digit,
       if we specify 1.0000, precision will be four digits. If rated,

--- a/splunk_eventgen/splunk_app/README/eventgen.conf.spec
+++ b/splunk_eventgen/splunk_app/README/eventgen.conf.spec
@@ -467,8 +467,7 @@ token.<n>.replacement = <string> | <strptime> | ["list","of","strptime"] | guid 
       and <end> is a number greater than 0 and greater than or equal to <start>.  If rated,
       will be multiplied times hourOfDayRate and dayOfWeekRate.
     * For float[<start>:<end>], the token will be replaced with a random float between
-      start and end values where <start> is a number greater than 0
-      and <end> is a number greater than 0 and greater than or equal to <start>.
+      start and end values where <end> is a number greater than or equal to <start>.
       For floating point numbers, precision will be based off the precision specified
       in <start>.  For example, if we specify 1.0, precision will be one digit, if we specify
       1.0000, precision will be four digits. If rated, will be multiplied times hourOfDayRate and dayOfWeekRate.


### PR DESCRIPTION
In PR #127 support for negative floats was introduced, as a fix for issue #126 .

Documentation added in that PR is not present anymore, this PR brings all docs up to date.
In the docs the mention that floats must be greater than 0 is removed.

Functionality is still present: 
- test exists: https://github.com/splunk/eventgen/blob/develop/tests/large/test_token_replacement.py#L56
- main regex: https://github.com/splunk/eventgen/blob/develop/splunk_eventgen/lib/eventgentoken.py#L179