### PR TITLE
default source

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -374,7 +374,7 @@ specifically be supported by all plugins. Plugins that write to files like spool
 
     source = <source>
     * Valid with outputMode=modinput (default) & outputMode=splunkstream & outputMode=httpevent
-    * Set event source in Splunk to <source>. Defaults to 'eventgen' if none specified.
+    * Set event source in Splunk to <source>. Defaults to sample file name if none specified.
 
     sourcetype = <sourcetype>
     * Valid with outputMode=modinput (default) & outputMode=splunkstream & outputMode=httpevent

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -44,7 +44,6 @@ fileBackupFiles = 5
 splunkPort = 8089
 splunkMethod = https
 index = main
-source = eventgen
 sourcetype = eventgen
 host = 127.0.0.1
 outputWorkers = 1
@@ -265,7 +264,7 @@ extendIndexes = <index_prefix>:<weight>,<index2>,<index3>
 source = <source>
     * Valid with the following outputMode:
       outputMode=modinput (default) & outputMode=splunkstream & outputMode=httpevent
-    * Set event source in Splunk to <source>. Defaults to 'eventgen' if none specified.
+    * Set event source in Splunk to <source>. Defaults to sample file name if none specified.
 
 sourcetype = <sourcetype>
     * Valid with the following outputMode:

--- a/splunk_eventgen/default/eventgen.conf
+++ b/splunk_eventgen/default/eventgen.conf
@@ -31,7 +31,6 @@ fileBackupFiles = 5
 splunkPort = 8089
 splunkMethod = https
 index = main
-source = eventgen
 sourcetype = eventgen
 host = 127.0.0.1
 generator = default

--- a/splunk_eventgen/lib/eventgen_defaults
+++ b/splunk_eventgen/lib/eventgen_defaults
@@ -21,6 +21,5 @@ fileBackupFiles = 5
 splunkPort = 8089
 splunkMethod = https
 index = main
-source = eventgen
 sourcetype = eventgen
 host = 127.0.0.1

--- a/splunk_eventgen/lib/eventgenconfig.py
+++ b/splunk_eventgen/lib/eventgenconfig.py
@@ -971,7 +971,7 @@ class Config(object):
                 s.generator = "replay"
             # 5/14/20 - Instead of using a static default source, leave source empty by default and
             # set it to the sample file name unless otherwise specified.
-            if not self.source:
+            if not s.source:
                 sample_path = s.filePath if s.filePath else s.generator
                 s.source = os.path.basename(sample_path)
 

--- a/splunk_eventgen/lib/eventgenconfig.py
+++ b/splunk_eventgen/lib/eventgenconfig.py
@@ -660,16 +660,14 @@ class Config(object):
                     else:
                         s.sampleDir = os.path.join(os.getcwd(), self.DEFAULT_SAMPLE_DIR)
                         if not os.path.exists(s.sampleDir):
-                            # use the prebuilt sample dirs as the last choice
-                            if not os.path.exists(s.sampleDir):
-                                newSampleDir = os.path.join(
-                                    self.grandparentdir, self.DEFAULT_SAMPLE_DIR
-                                )
-                                logger.error(
-                                    "Path not found for samples '%s', trying '%s'"
-                                    % (s.sampleDir, newSampleDir)
-                                )
-                                s.sampleDir = newSampleDir
+                            newSampleDir = os.path.join(
+                                self.grandparentdir, self.DEFAULT_SAMPLE_DIR
+                            )
+                            logger.error(
+                                "Path not found for samples '%s', trying '%s'"
+                                % (s.sampleDir, newSampleDir)
+                            )
+                            s.sampleDir = newSampleDir
             else:
                 if not os.path.isabs(s.sampleDir):
                     # relative path use the conffile dir as the base dir
@@ -974,7 +972,8 @@ class Config(object):
             # 5/14/20 - Instead of using a static default source, leave source empty by default and
             # set it to the sample file name unless otherwise specified.
             if not self.source:
-                s.source = os.path.basename(s.filePath)
+                sample_path = s.filePath if s.filePath else s.generator
+                s.source = os.path.basename(sample_path)
 
         self.samples = tempsamples
         self._confDict = None

--- a/splunk_eventgen/lib/eventgenconfig.py
+++ b/splunk_eventgen/lib/eventgenconfig.py
@@ -971,6 +971,10 @@ class Config(object):
                 s.interval = 0 if not s.interval else s.interval
                 # 12/29/13 CS Moved replay generation to a new replay generator plugin
                 s.generator = "replay"
+            # 5/25/20 - Instead of using a static default source, leave source empty by default and
+            # set it to the sample file name unless otherwise specified.
+            if not self.source:
+                s.source = os.path.basename(s.filePath)
 
         self.samples = tempsamples
         self._confDict = None

--- a/splunk_eventgen/lib/eventgenconfig.py
+++ b/splunk_eventgen/lib/eventgenconfig.py
@@ -971,7 +971,7 @@ class Config(object):
                 s.interval = 0 if not s.interval else s.interval
                 # 12/29/13 CS Moved replay generation to a new replay generator plugin
                 s.generator = "replay"
-            # 5/25/20 - Instead of using a static default source, leave source empty by default and
+            # 5/14/20 - Instead of using a static default source, leave source empty by default and
             # set it to the sample file name unless otherwise specified.
             if not self.source:
                 s.source = os.path.basename(s.filePath)

--- a/splunk_eventgen/splunk_app/README/eventgen.conf.spec
+++ b/splunk_eventgen/splunk_app/README/eventgen.conf.spec
@@ -47,7 +47,6 @@ fileBackupFiles = 5
 splunkPort = 8089
 splunkMethod = https
 index = main
-source = eventgen
 sourcetype = eventgen
 host = 127.0.0.1
 outputWorkers = 1
@@ -219,7 +218,7 @@ index = <index>
 
 source = <source>
     * Valid with outputMode=modinput (default) & outputMode=splunkstream & outputMode=httpevent
-    * Set event source in Splunk to <source>.  Defaults to 'eventgen' if none specified.
+    * Set event source in Splunk to <source>.  Defaults to sample file name if none specified.
 
 sourcetype = <sourcetype>
     * Valid with outputMode=modinput (default) & outputMode=splunkstream & outputMode=httpevent

--- a/tests/large/conf/eventgen_output_modinput.conf
+++ b/tests/large/conf/eventgen_output_modinput.conf
@@ -5,6 +5,7 @@ earliest = -15s
 sampletype = raw
 outputMode = modinput
 end = 1
+source = eventgen
 
 token.0.token = \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}
 token.0.replacementType = timestamp


### PR DESCRIPTION
For #394 
Changes the default source behavior to use the sample file name. Specifying a source in eventgen.conf still has the same behavior, and will prevent this.